### PR TITLE
Feature: sync filament (AFC integration)

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -138,7 +138,7 @@ async def printer_status(include_webcams: bool = False):
         print_status = None
         webcams = []
         try:
-            print_status = await client.query_print_status()
+            print_status = await client.query_print_status(include_afc=True)
         except Exception:
             pass  # Non-critical
 

--- a/apps/api/app/moonraker.py
+++ b/apps/api/app/moonraker.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 from typing import Optional, Dict, Any
 from urllib.parse import urljoin, urlparse, urlunparse
@@ -119,7 +120,7 @@ class MoonrakerClient:
         response.raise_for_status()
         return response.json()
 
-    async def query_print_status(self) -> Dict[str, Any]:
+    async def query_print_status(self, include_afc: bool = False) -> Dict[str, Any]:
         """Query printer objects for print status, progress, and temperatures."""
         if not self.client:
             raise RuntimeError("Client not connected. Call connect() first.")
@@ -162,6 +163,13 @@ class MoonrakerClient:
 
         active_extruder = data.get(active_extruder_name, data.get("extruder", {}))
 
+        afc_slots = []
+        if include_afc:
+            try:
+                afc_slots = await self.query_afc_slots()
+            except Exception:
+                afc_slots = []
+
         return {
             "state": print_stats.get("state", "standby"),
             "progress": virtual_sdcard.get("progress", 0.0),
@@ -173,7 +181,213 @@ class MoonrakerClient:
             "bed_temp": heater_bed.get("temperature", 0.0),
             "bed_target": heater_bed.get("target", 0.0),
             "extruders": extruders,
+            "afc_slots": afc_slots,
         }
+
+    async def query_afc_slots(self) -> list[dict[str, Any]]:
+        """Discover AFC-related Moonraker objects and extract loaded color info."""
+        if not self.client:
+            raise RuntimeError("Client not connected. Call connect() first.")
+
+        list_response = await self.client.get("/printer/objects/list")
+        list_response.raise_for_status()
+        objects = list_response.json().get("result", {}).get("objects", [])
+
+        afc_objects = [name for name in objects if "afc" in str(name).lower()]
+        if not afc_objects:
+            return []
+
+        query_params = {name: "" for name in afc_objects}
+        query_response = await self.client.get("/printer/objects/query", params=query_params)
+        query_response.raise_for_status()
+        status = query_response.json().get("result", {}).get("status", {})
+
+        slots: list[dict[str, Any]] = []
+        seen: set[tuple[str, str, Optional[str], Optional[str], Optional[bool], Optional[bool]]] = set()
+
+        def _walk(path: str, node: Any):
+            if isinstance(node, dict):
+                color = self._extract_hex_color(node)
+                # Require at least one lane-identifying key to avoid emitting
+                # phantom slots from nested config objects that happen to have a color
+                lane_keys = ("loaded", "tool_loaded", "lane", "slot", "index", "name")
+                has_lane_hint = any(node.get(k) is not None for k in lane_keys)
+                if color and has_lane_hint:
+                    label = self._extract_slot_label(path, node)
+                    loaded = self._extract_loaded_state(node)
+                    tool_loaded = self._extract_tool_loaded_state(node)
+                    material_type = self._extract_material_type(node)
+                    manufacturer = self._extract_manufacturer(node)
+                    key = (label, color, material_type, manufacturer, loaded, tool_loaded)
+                    if key not in seen:
+                        seen.add(key)
+                        slots.append({
+                            "label": label,
+                            "color": color,
+                            "loaded": loaded,
+                            "tool_loaded": tool_loaded,
+                            "material_type": material_type,
+                            "manufacturer": manufacturer,
+                        })
+
+                for key, value in node.items():
+                    next_path = f"{path}.{key}" if path else str(key)
+                    _walk(next_path, value)
+
+            elif isinstance(node, list):
+                for idx, item in enumerate(node):
+                    _walk(f"{path}[{idx}]", item)
+
+        for object_name in afc_objects:
+            _walk(object_name, status.get(object_name, {}))
+
+        # Safety cap: AFC systems typically have 4-12 lanes max
+        return slots[:12]
+
+    @staticmethod
+    def _extract_hex_color(node: dict[str, Any]) -> Optional[str]:
+        color_keys = [
+            "color", "colour", "color_hex", "colour_hex", "hex",
+            "spool_color", "filament_color", "loaded_color",
+        ]
+        for key in color_keys:
+            value = node.get(key)
+            normalized = MoonrakerClient._normalize_hex(value)
+            if normalized:
+                return normalized
+        return None
+
+    @staticmethod
+    def _normalize_hex(value: Any) -> Optional[str]:
+        if not isinstance(value, str):
+            return None
+        candidate = value.strip()
+        if not candidate:
+            return None
+        if not candidate.startswith("#"):
+            candidate = f"#{candidate}"
+        if re.fullmatch(r"#[0-9a-fA-F]{6}", candidate):
+            return candidate.upper()
+        return None
+
+    @staticmethod
+    def _extract_loaded_state(node: dict[str, Any]) -> Optional[bool]:
+        bool_keys = ["loaded", "is_loaded", "filament_present", "has_filament", "load", "prep"]
+        for key in bool_keys:
+            value = node.get(key)
+            if isinstance(value, bool):
+                return value
+        return None
+
+    @staticmethod
+    def _extract_tool_loaded_state(node: dict[str, Any]) -> Optional[bool]:
+        bool_keys = ["tool_loaded", "loaded_to_tool", "loaded_to_nozzle", "nozzle_loaded"]
+        for key in bool_keys:
+            value = node.get(key)
+            if isinstance(value, bool):
+                return value
+        return None
+
+    @staticmethod
+    def _extract_slot_label(path: str, node: dict[str, Any]) -> str:
+        name = node.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+        if node.get("lane") is not None:
+            return f"Lane {node.get('lane')}"
+        if node.get("slot") is not None:
+            return f"Slot {node.get('slot')}"
+        if node.get("index") is not None:
+            return f"Slot {node.get('index')}"
+        tail = path.split(".")[-1] if path else "AFC"
+        return str(tail)
+
+    @staticmethod
+    def _extract_material_type(node: dict[str, Any]) -> Optional[str]:
+        material_keys = [
+            "material", "material_type", "filament_material",
+            "filament_type", "spool_material", "mat",
+        ]
+        for key in material_keys:
+            value = node.get(key)
+            normalized = MoonrakerClient._normalize_material_type(value)
+            if normalized:
+                return normalized
+        return None
+
+    @staticmethod
+    def _normalize_material_type(value: Any) -> Optional[str]:
+        if not isinstance(value, str):
+            return None
+        candidate = value.strip().upper().replace(" ", "")
+        if not candidate:
+            return None
+        aliases = {
+            "PLA+": "PLA", "PLAPLUS": "PLA", "PET-G": "PETG",
+            "ABS+": "ABS", "NYLON": "PA", "PA6": "PA", "PA12": "PA",
+        }
+        candidate = aliases.get(candidate, candidate)
+        known = {"PLA", "PETG", "ABS", "ASA", "TPU", "PC", "PA", "PVA", "HIPS"}
+        if candidate in known:
+            return candidate
+        return candidate if len(candidate) <= 12 and re.fullmatch(r"[A-Z0-9_+\-]+", candidate) else None
+
+    @staticmethod
+    def _extract_manufacturer(node: dict[str, Any]) -> Optional[str]:
+        manufacturer_keys = [
+            "manufacturer", "brand", "vendor", "vendor_name", "maker",
+            "filament_brand", "material_brand", "spool_brand", "mfr", "supplier",
+        ]
+        for key in manufacturer_keys:
+            value = node.get(key)
+            if isinstance(value, str):
+                cleaned = value.strip()
+                if cleaned:
+                    return cleaned
+
+        for key, value in node.items():
+            key_l = str(key).lower()
+            if any(token in key_l for token in ("manufacturer", "brand", "vendor", "maker", "mfr", "supplier")):
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+                if isinstance(value, list) and value and isinstance(value[0], str) and value[0].strip():
+                    return value[0].strip()
+
+        for key in ("filament_name", "spool_name", "profile_name", "material_name", "name"):
+            value = node.get(key)
+            if not isinstance(value, str):
+                continue
+            guessed = MoonrakerClient._guess_manufacturer_from_name(value)
+            if guessed:
+                return guessed
+
+        return None
+
+    @staticmethod
+    def _guess_manufacturer_from_name(name: str) -> Optional[str]:
+        if not isinstance(name, str):
+            return None
+        text = name.strip()
+        if not text:
+            return None
+
+        known = {
+            "bambu": "Bambu", "sunlu": "Sunlu", "esun": "eSUN",
+            "polymaker": "Polymaker", "prusament": "Prusament", "snapmaker": "Snapmaker",
+        }
+        lower = text.lower()
+        for token, canonical in known.items():
+            if token in lower:
+                return canonical
+
+        first = re.split(r"[\s_\-]+", text)[0].strip("()[]")
+        if not first or len(first) < 3:
+            return None
+        if re.fullmatch(r"(?i)(pla|petg|abs|asa|tpu|pc|pa|pva)", first):
+            return None
+        if re.fullmatch(r"[A-Za-z][A-Za-z0-9+._]*", first):
+            return first
+        return None
 
     def _build_base_url(self, keep_port: bool) -> str:
         parsed_base = urlparse(self.base_url)

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1231,7 +1231,16 @@
 
             <!-- Extruder Presets -->
             <div class="mb-6 p-4 bg-gray-50 rounded-lg">
-                <h3 class="text-sm font-medium text-gray-700 mb-3">Extruder Presets (E1-E4)</h3>
+                <div class="flex items-center justify-between mb-2">
+                    <h3 class="text-sm font-medium text-gray-700">Extruder Presets (E1-E4)</h3>
+                    <button @click="loadAfcColorsIntoPresets()"
+                            :disabled="afcSyncing"
+                            class="px-2.5 py-1.5 text-xs border border-indigo-300 text-indigo-700 rounded-lg hover:bg-indigo-50 transition"
+                            title="Load currently loaded AFC colors into E1-E4 preset colors">
+                        <span x-show="!afcSyncing">Load AFC Colors</span>
+                        <span x-show="afcSyncing">Syncing...</span>
+                    </button>
+                </div>
                 <p class="text-xs text-gray-500 mb-3">Set default filament profile and color for each slot. These are used by default for new slices.</p>
 
                 <div class="space-y-2">
@@ -1994,6 +2003,26 @@
                                     </div>
                                 </template>
                             </div>
+                        </div>
+                    </div>
+
+                    <!-- AFC Colors (from Moonraker objects) -->
+                    <div x-show="printerConnected && printerAfcSlots.length > 0" x-cloak class="mb-4 p-3 bg-indigo-50 border border-indigo-200 rounded-lg">
+                        <p class="text-xs font-medium text-indigo-800 mb-2">Loaded AFC Colors</p>
+                        <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs">
+                            <template x-for="(slot, i) in printerAfcSlots" :key="`${slot.label}-${slot.color}-${i}`">
+                                <div class="flex items-center gap-2 p-2 bg-white rounded border border-indigo-100"
+                                     :title="`Manufacturer: ${slot.manufacturer || 'not reported by printer'}`">
+                                    <div class="w-4 h-4 rounded-full border border-gray-300" :style="`background-color: ${slot.color || '#e5e7eb'}`"></div>
+                                    <div class="min-w-0">
+                                        <p class="font-medium text-gray-800 truncate" x-text="`E${i+1}`" :title="slot.label"></p>
+                                        <p class="text-[11px]" :class="slot.loaded === false ? 'text-gray-400' : 'text-indigo-700'"
+                                           x-text="slot.material_type
+                                              ? `${slot.material_type} · ${slot.tool_loaded === true ? 'At nozzle' : (slot.loaded === true ? 'Loaded in lane' : 'Not loaded')}`
+                                              : (slot.tool_loaded === true ? 'At nozzle' : (slot.loaded === true ? 'Loaded in lane' : 'Not loaded'))"></p>
+                                    </div>
+                                </div>
+                            </template>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- Adds AFC (Automated Filament Changer) integration via Moonraker
- Discovers AFC slots dynamically, displays color/material/load-state in Printer Status overlay
- "Load AFC Colors" button in Settings syncs AFC lane data into extruder presets (E1-E4)
- Based on #7 from @kabakakao with review fixes applied

## Review fixes applied
- Removed unnecessary `_query_print_status` rename (reduces merge conflicts)
- Tightened recursive AFC walker to require lane-identifying keys (prevents phantom slots)
- Removed overly generic `"type"` from material_keys
- Shows `slot.label` as tooltip on AFC Printer Status display
- Fixed `presetMessage` timer race in `loadAfcColorsIntoPresets`
- Added edge-case tests for "printer offline" and "no AFC slots found"
- Reverted unrelated release workflow changes (preserves arm64 builds)

## Test plan
- [ ] Existing settings tests pass
- [ ] New AFC edge-case tests pass (offline, no slots)
- [ ] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)