### PR TITLE
Hide AFC button on printers without AFC firmware

### DIFF
--- a/apps/web/app.js
+++ b/apps/web/app.js
@@ -82,6 +82,7 @@ function app() {
         printerBusy: false,
         printerStatus: 'Checking...',
         printerWebcams: [],
+        printerHasAfc: false,
         printerAfcSlots: [],
         webcamsExpanded: false,
         webcamImageFallback: {},
@@ -254,6 +255,7 @@ function app() {
                     this.webcamImageFallback = {};
                     this.webcamImageNonce = Date.now();
                 }
+                this.printerHasAfc = status.print_status?.has_afc || false;
                 this.printerAfcSlots = status.print_status?.afc_slots || [];
                 // Show print progress in header when actively printing
                 if (status.print_status && status.print_status.state === 'printing') {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1233,7 +1233,8 @@
             <div class="mb-6 p-4 bg-gray-50 rounded-lg">
                 <div class="flex items-center justify-between mb-2">
                     <h3 class="text-sm font-medium text-gray-700">Extruder Presets (E1-E4)</h3>
-                    <button @click="loadAfcColorsIntoPresets()"
+                    <button x-show="printerHasAfc" x-cloak
+                            @click="loadAfcColorsIntoPresets()"
                             :disabled="afcSyncing"
                             class="px-2.5 py-1.5 text-xs border border-indigo-300 text-indigo-700 rounded-lg hover:bg-indigo-50 transition"
                             title="Load currently loaded AFC colors into E1-E4 preset colors">

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -78,9 +78,13 @@ test.describe('Settings Modal', () => {
         const scopes = body?._x_dataStack || [];
         for (const scope of scopes) {
           if ('checkPrinterStatus' in scope && 'printerAfcSlots' in scope) {
+            scope.printerHasAfc = true;
+            const highestId = window.setInterval(() => {}, 99999);
+            for (let i = 1; i <= highestId; i++) window.clearInterval(i);
             scope.checkPrinterStatus = async function () {
               this.printerConnected = true;
               this.printerStatus = 'Connected';
+              this.printerHasAfc = true;
               this.printerAfcSlots = [{
                 label: 'Slot 2',
                 color: '#112233',
@@ -94,6 +98,8 @@ test.describe('Settings Modal', () => {
         }
       }, manufacturerHint);
 
+      // Wait for Alpine reactivity to show the button after setting printerHasAfc
+      await page.getByRole('button', { name: 'Load AFC Colors' }).waitFor({ state: 'visible', timeout: 5_000 });
       await page.getByRole('button', { name: 'Load AFC Colors' }).click();
 
       await page.waitForFunction(() => {
@@ -132,9 +138,13 @@ test.describe('Settings Modal', () => {
       const scopes = body?._x_dataStack || [];
       for (const scope of scopes) {
         if ('checkPrinterStatus' in scope && 'printerAfcSlots' in scope) {
+          scope.printerHasAfc = true;
+          const highestId = window.setInterval(() => {}, 99999);
+          for (let i = 1; i <= highestId; i++) window.clearInterval(i);
           scope.checkPrinterStatus = async function () {
             this.printerConnected = false;
             this.printerStatus = 'Disconnected';
+            this.printerHasAfc = true;
             this.printerAfcSlots = [];
           };
           break;
@@ -142,6 +152,7 @@ test.describe('Settings Modal', () => {
       }
     });
 
+    await page.getByRole('button', { name: 'Load AFC Colors' }).waitFor({ state: 'visible', timeout: 5_000 });
     await page.getByRole('button', { name: 'Load AFC Colors' }).click();
 
     await page.waitForFunction(() => {
@@ -170,9 +181,15 @@ test.describe('Settings Modal', () => {
       const scopes = body?._x_dataStack || [];
       for (const scope of scopes) {
         if ('checkPrinterStatus' in scope && 'printerAfcSlots' in scope) {
+          scope.printerHasAfc = true;
+          // Replace checkPrinterStatus with a mock that preserves printerHasAfc,
+          // and clear all intervals to prevent real status polling from overwriting it
+          const highestId = window.setInterval(() => {}, 99999);
+          for (let i = 1; i <= highestId; i++) window.clearInterval(i);
           scope.checkPrinterStatus = async function () {
             this.printerConnected = true;
             this.printerStatus = 'Connected';
+            this.printerHasAfc = true;
             this.printerAfcSlots = [];
           };
           break;
@@ -180,6 +197,7 @@ test.describe('Settings Modal', () => {
       }
     });
 
+    await page.getByRole('button', { name: 'Load AFC Colors' }).waitFor({ state: 'visible', timeout: 5_000 });
     await page.getByRole('button', { name: 'Load AFC Colors' }).click();
 
     await page.waitForFunction(() => {


### PR DESCRIPTION
## Summary
- Backend `query_afc_slots()` now returns `has_afc` boolean alongside slots — `true` only when AFC Klipper objects exist on the printer
- Frontend "Load AFC Colors" button conditionally shown via `x-show="printerHasAfc"`
- Standard Snapmaker U1 firmware returns `has_afc: false` (verified against live printer)
- AFC tests hardened against status-polling race conditions

## Test plan
- [x] 117/117 fast tests passing
- [x] Verified `has_afc: false` on standard Snapmaker firmware (192.168.0.151)
- [x] AFC tests mock `printerHasAfc = true` to exercise button visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)