### PR TITLE
Replace AFC sync with universal Sync from Printer

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -138,7 +138,7 @@ async def printer_status(include_webcams: bool = False):
         print_status = None
         webcams = []
         try:
-            print_status = await client.query_print_status(include_afc=True)
+            print_status = await client.query_print_status(include_filament_config=True)
         except Exception:
             pass  # Non-critical
 

--- a/apps/web/app.js
+++ b/apps/web/app.js
@@ -74,6 +74,10 @@ function app() {
         presetMessageOk: true,
         _presetMessageTimer: null,
         filamentSyncing: false,
+        syncPreviewOpen: false,
+        syncPreviewSlots: [],
+        syncApplyColors: true,
+        syncApplyProfiles: true,
         maxExtruders: 4,
         multicolorNotice: null,
 
@@ -402,13 +406,13 @@ function app() {
             }
         },
 
-        async loadPrinterColorsIntoPresets() {
+        async prepareSyncPreview() {
             this.presetMessage = null;
             this.presetMessageOk = true;
+            this.syncPreviewOpen = false;
             this.filamentSyncing = true;
             try {
                 await this.checkPrinterStatus();
-                const slots = (this.printerFilamentSlots || []).filter((slot) => slot && slot.color && slot.loaded !== false);
 
                 if (!this.printerConnected) {
                     this.presetMessage = 'Printer offline — cannot sync filament colors.';
@@ -416,35 +420,85 @@ function app() {
                     return;
                 }
 
+                const slots = (this.printerFilamentSlots || []).filter((slot) => slot && slot.color && slot.loaded !== false);
                 if (slots.length === 0) {
                     this.presetMessage = 'No filament detected on printer.';
                     this.presetMessageOk = false;
                     return;
                 }
 
-                for (let i = 0; i < Math.min(slots.length, this.maxExtruders); i++) {
-                    const slot = slots[i];
-                    this.extruderPresets[i].color_hex = slot.color;
+                const preview = [];
+                for (let i = 0; i < this.maxExtruders; i++) {
+                    const printerSlot = i < slots.length ? slots[i] : null;
+                    const preset = this.extruderPresets[i];
+                    const currentFilament = preset.filament_id
+                        ? (this.filaments || []).find(f => f.id === Number(preset.filament_id))
+                        : null;
+                    const match = printerSlot && printerSlot.material_type
+                        ? this.findFilamentMatchForSlot(printerSlot)
+                        : null;
 
-                    if (slot.material_type && this.filaments && this.filaments.length > 0) {
-                        const match = this.findFilamentMatchForSlot(slot);
-                        if (match) {
-                            this.extruderPresets[i].filament_id = match.id;
-                        }
-                    }
+                    preview.push({
+                        slotIndex: i,
+                        label: `E${i + 1}`,
+                        hasFilament: !!printerSlot,
+                        currentColor: preset.color_hex || '#FFFFFF',
+                        newColor: printerSlot ? printerSlot.color : null,
+                        colorChanged: printerSlot ? (preset.color_hex || '#FFFFFF').toUpperCase() !== (printerSlot.color || '').toUpperCase() : false,
+                        currentFilamentId: preset.filament_id || null,
+                        currentFilamentName: currentFilament ? currentFilament.name : null,
+                        matchedFilament: match ? { id: match.id, name: match.name } : null,
+                        profileChanged: match ? match.id !== Number(preset.filament_id) : false,
+                        printerMaterial: printerSlot ? printerSlot.material_type : null,
+                        printerManufacturer: printerSlot ? printerSlot.manufacturer : null,
+                    });
                 }
 
-                await this.saveExtruderPresets();
-                if (this._presetMessageTimer) clearTimeout(this._presetMessageTimer);
-                this.presetMessage = 'Synced filament colors from printer.';
-                this.presetMessageOk = true;
-                this._presetMessageTimer = setTimeout(() => { this.presetMessage = null; }, 5000);
+                this.syncPreviewSlots = preview;
+                this.syncApplyColors = true;
+                this.syncApplyProfiles = true;
+                this.syncPreviewOpen = true;
             } catch (err) {
                 this.presetMessage = `Failed to sync filament colors: ${err.message}`;
                 this.presetMessageOk = false;
                 this.showError(this.presetMessage);
             } finally {
                 this.filamentSyncing = false;
+            }
+        },
+
+        cancelSyncPreview() {
+            this.syncPreviewOpen = false;
+            this.syncPreviewSlots = [];
+        },
+
+        async applySyncPreview() {
+            try {
+                for (const slot of this.syncPreviewSlots) {
+                    if (!slot.hasFilament) continue;
+                    if (this.syncApplyColors && slot.newColor) {
+                        this.extruderPresets[slot.slotIndex].color_hex = slot.newColor;
+                    }
+                    if (this.syncApplyProfiles && slot.matchedFilament) {
+                        this.extruderPresets[slot.slotIndex].filament_id = slot.matchedFilament.id;
+                    }
+                }
+
+                await this.saveExtruderPresets();
+                this.syncPreviewOpen = false;
+                this.syncPreviewSlots = [];
+
+                if (this._presetMessageTimer) clearTimeout(this._presetMessageTimer);
+                const parts = [];
+                if (this.syncApplyColors) parts.push('colors');
+                if (this.syncApplyProfiles) parts.push('filament profiles');
+                this.presetMessage = `Synced ${parts.join(' and ')} from printer.`;
+                this.presetMessageOk = true;
+                this._presetMessageTimer = setTimeout(() => { this.presetMessage = null; }, 5000);
+            } catch (err) {
+                this.presetMessage = `Failed to sync: ${err.message}`;
+                this.presetMessageOk = false;
+                this.showError(this.presetMessage);
             }
         },
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1234,8 +1234,8 @@
                 <div class="flex items-center justify-between mb-2">
                     <h3 class="text-sm font-medium text-gray-700">Extruder Presets (E1-E4)</h3>
                     <button x-show="printerHasFilamentConfig" x-cloak
-                            @click="loadPrinterColorsIntoPresets()"
-                            :disabled="filamentSyncing"
+                            @click="prepareSyncPreview()"
+                            :disabled="filamentSyncing || syncPreviewOpen"
                             class="px-2.5 py-1.5 text-xs border border-indigo-300 text-indigo-700 rounded-lg hover:bg-indigo-50 transition"
                             title="Sync filament colors from printer into E1-E4 presets">
                         <span x-show="!filamentSyncing">Sync from Printer</span>
@@ -1261,6 +1261,68 @@
                             </select>
                         </div>
                     </template>
+                </div>
+
+                <!-- Sync Preview Panel -->
+                <div x-show="syncPreviewOpen" x-cloak class="mt-3 p-3 border border-indigo-200 bg-indigo-50 rounded-lg">
+                    <p class="text-xs font-medium text-indigo-900 mb-2">Sync Preview</p>
+                    <div class="space-y-2 mb-3">
+                        <template x-for="slot in syncPreviewSlots" :key="slot.slotIndex">
+                            <div class="text-xs">
+                                <template x-if="slot.hasFilament">
+                                    <div class="p-2 bg-white rounded border border-indigo-100">
+                                        <div class="flex items-center gap-2 mb-1">
+                                            <span class="font-medium text-gray-800 w-6" x-text="slot.label"></span>
+                                            <div class="w-4 h-4 rounded-full border border-gray-300 flex-shrink-0" :style="`background-color: ${slot.currentColor}`"></div>
+                                            <span class="text-gray-400">&rarr;</span>
+                                            <div class="w-4 h-4 rounded-full border border-gray-300 flex-shrink-0" :style="`background-color: ${slot.newColor}`"></div>
+                                            <span x-show="!slot.colorChanged" class="text-gray-400 text-[10px]">(no change)</span>
+                                            <span class="ml-auto text-indigo-700 text-[11px]" x-text="[slot.printerMaterial, slot.printerManufacturer].filter(Boolean).join(' · ')"></span>
+                                        </div>
+                                        <div class="flex items-center gap-1 pl-8 text-[11px]">
+                                            <span class="text-gray-500" x-text="slot.currentFilamentName || 'No profile'"></span>
+                                            <template x-if="slot.matchedFilament">
+                                                <span>
+                                                    <span class="text-gray-400">&rarr;</span>
+                                                    <span :class="slot.profileChanged ? 'text-indigo-700 font-medium' : 'text-gray-400'" x-text="slot.matchedFilament.name"></span>
+                                                    <span x-show="!slot.profileChanged" class="text-gray-400">(same)</span>
+                                                </span>
+                                            </template>
+                                            <template x-if="!slot.matchedFilament">
+                                                <span class="text-gray-400 italic">no match</span>
+                                            </template>
+                                        </div>
+                                    </div>
+                                </template>
+                                <template x-if="!slot.hasFilament">
+                                    <div class="p-2 text-gray-400 italic">
+                                        <span x-text="slot.label"></span> — no filament on printer, skipped
+                                    </div>
+                                </template>
+                            </div>
+                        </template>
+                    </div>
+                    <div class="flex items-center gap-4 mb-3 text-xs">
+                        <label class="flex items-center gap-1.5 cursor-pointer">
+                            <input type="checkbox" x-model="syncApplyColors" class="rounded border-gray-300 text-indigo-600">
+                            <span class="text-gray-700">Apply colors</span>
+                        </label>
+                        <label class="flex items-center gap-1.5 cursor-pointer">
+                            <input type="checkbox" x-model="syncApplyProfiles" class="rounded border-gray-300 text-indigo-600">
+                            <span class="text-gray-700">Apply filament profiles</span>
+                        </label>
+                    </div>
+                    <div class="flex gap-2">
+                        <button @click="applySyncPreview()"
+                                :disabled="!syncApplyColors && !syncApplyProfiles"
+                                class="px-3 py-1 text-xs bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition">
+                            Apply
+                        </button>
+                        <button @click="cancelSyncPreview()"
+                                class="px-3 py-1 text-xs border border-gray-300 text-gray-700 rounded hover:bg-gray-50 transition">
+                            Cancel
+                        </button>
+                    </div>
                 </div>
             </div>
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1233,13 +1233,13 @@
             <div class="mb-6 p-4 bg-gray-50 rounded-lg">
                 <div class="flex items-center justify-between mb-2">
                     <h3 class="text-sm font-medium text-gray-700">Extruder Presets (E1-E4)</h3>
-                    <button x-show="printerHasAfc" x-cloak
-                            @click="loadAfcColorsIntoPresets()"
-                            :disabled="afcSyncing"
+                    <button x-show="printerHasFilamentConfig" x-cloak
+                            @click="loadPrinterColorsIntoPresets()"
+                            :disabled="filamentSyncing"
                             class="px-2.5 py-1.5 text-xs border border-indigo-300 text-indigo-700 rounded-lg hover:bg-indigo-50 transition"
-                            title="Load currently loaded AFC colors into E1-E4 preset colors">
-                        <span x-show="!afcSyncing">Load AFC Colors</span>
-                        <span x-show="afcSyncing">Syncing...</span>
+                            title="Sync filament colors from printer into E1-E4 presets">
+                        <span x-show="!filamentSyncing">Sync from Printer</span>
+                        <span x-show="filamentSyncing">Syncing...</span>
                     </button>
                 </div>
                 <p class="text-xs text-gray-500 mb-3">Set default filament profile and color for each slot. These are used by default for new slices.</p>
@@ -2007,11 +2007,11 @@
                         </div>
                     </div>
 
-                    <!-- AFC Colors (from Moonraker objects) -->
-                    <div x-show="printerConnected && printerAfcSlots.length > 0" x-cloak class="mb-4 p-3 bg-indigo-50 border border-indigo-200 rounded-lg">
-                        <p class="text-xs font-medium text-indigo-800 mb-2">Loaded AFC Colors</p>
+                    <!-- Filament Colors (from Moonraker printer config) -->
+                    <div x-show="printerConnected && printerFilamentSlots.length > 0" x-cloak class="mb-4 p-3 bg-indigo-50 border border-indigo-200 rounded-lg">
+                        <p class="text-xs font-medium text-indigo-800 mb-2">Printer Filament Colors</p>
                         <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs">
-                            <template x-for="(slot, i) in printerAfcSlots" :key="`${slot.label}-${slot.color}-${i}`">
+                            <template x-for="(slot, i) in printerFilamentSlots" :key="`${slot.label}-${slot.color}-${i}`">
                                 <div class="flex items-center gap-2 p-2 bg-white rounded border border-indigo-100"
                                      :title="`Manufacturer: ${slot.manufacturer || 'not reported by printer'}`">
                                     <div class="w-4 h-4 rounded-full border border-gray-300" :style="`background-color: ${slot.color || '#e5e7eb'}`"></div>
@@ -2019,8 +2019,8 @@
                                         <p class="font-medium text-gray-800 truncate" x-text="`E${i+1}`" :title="slot.label"></p>
                                         <p class="text-[11px]" :class="slot.loaded === false ? 'text-gray-400' : 'text-indigo-700'"
                                            x-text="slot.material_type
-                                              ? `${slot.material_type} · ${slot.tool_loaded === true ? 'At nozzle' : (slot.loaded === true ? 'Loaded in lane' : 'Not loaded')}`
-                                              : (slot.tool_loaded === true ? 'At nozzle' : (slot.loaded === true ? 'Loaded in lane' : 'Not loaded'))"></p>
+                                              ? `${slot.material_type} · ${slot.manufacturer || ''}`
+                                              : (slot.loaded === true ? 'Loaded' : 'Not loaded')"></p>
                                     </div>
                                 </div>
                             </template>

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -102,12 +102,24 @@ test.describe('Settings Modal', () => {
       await page.getByRole('button', { name: 'Sync from Printer' }).waitFor({ state: 'visible', timeout: 5_000 });
       await page.getByRole('button', { name: 'Sync from Printer' }).click();
 
+      // Wait for sync preview panel to appear
+      await page.waitForFunction(() => {
+        const body = document.querySelector('body') as any;
+        for (const scope of (body?._x_dataStack || [])) {
+          if ('syncPreviewOpen' in scope) return scope.syncPreviewOpen === true;
+        }
+        return false;
+      }, undefined, { timeout: 10_000 });
+
+      // Click Apply in the preview panel
+      await page.getByRole('button', { name: 'Apply' }).click();
+
       await page.waitForFunction(() => {
         const body = document.querySelector('body') as any;
         if (body?._x_dataStack) {
           for (const scope of body._x_dataStack) {
             if ('presetMessage' in scope) {
-              return String(scope.presetMessage || '').includes('Synced filament colors from printer.');
+              return String(scope.presetMessage || '').includes('Synced colors and filament profiles from printer.');
             }
           }
         }


### PR DESCRIPTION
## Summary
- **Backend**: New `query_filament_config()` queries `print_task_config` (works for ALL users) enriched with `filament_detect` NFC data (manufacturer) when available. Falls back to AFC for custom firmware users.
- **Frontend**: "Load AFC Colors" button → "Sync from Printer", all AFC-specific state/functions renamed to generic filament terminology. Printer Status overlay updated to show `material · manufacturer`.
- **Tests**: 3 settings tests renamed and updated — all 117 fast tests passing.

## Test plan
- [x] `npm run test:fast` — 117/117 pass
- [ ] Browser: Settings → "Sync from Printer" button visible when printer connected
- [ ] Browser: Click button → filament colors populate E1-E4 presets
- [ ] Browser: Printer Status overlay shows filament color cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)