### PR TITLE
Optimize processing pipeline: reduce redundant ZIP opens and cache G-code bounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ Avoid:
 - hidden state
 - plaintext secrets
 - skipping tests after changes (even "small" ones can break things)
+- **assuming test failures are pre-existing or flaky** — if a test fails after your changes, investigate it as a regression caused by your code. Never dismiss failures without evidence they were already failing before your changes
 
 ### Release & Docker Images
 

--- a/apps/api/app/gcode_parser.py
+++ b/apps/api/app/gcode_parser.py
@@ -6,6 +6,13 @@ from dataclasses import dataclass, field
 import re
 
 
+# Module-level compiled regex patterns (avoid recompilation per call)
+_RE_COORD = re.compile(r'([XYZ])([\d.-]+)')
+_RE_GCODE_FIELDS = re.compile(r'([GXYZEF])([\d.-]+)')
+_RE_LAYER_CHANGE = re.compile(r'^;\s*(LAYER_CHANGE|CHANGE_LAYER)\b', re.IGNORECASE)
+_RE_LAYER_NUMBER = re.compile(r'^;\s*LAYER\s*:\s*(\d+)\b', re.IGNORECASE)
+
+
 @dataclass
 class GCodeMetadata:
     estimated_time_seconds: int
@@ -43,106 +50,128 @@ def parse_time_to_seconds(time_str: str) -> int:
 
 
 def parse_orca_metadata(gcode_path: Path) -> GCodeMetadata:
-    """Parse Orca Slicer comments for metadata.
+    """Parse Orca Slicer comments for metadata in a single pass.
 
-    Orca embeds metadata in comments like:
-    ; estimated printing time (normal mode) = 1h 23m 45s
-    ; filament used [mm] = 1234.5
-    ; total layer number: 100 (in header)
-
-    Note: Time and filament metadata appears at the END of the file,
-    while layer count appears in the header at the beginning.
+    Reads the file once: extracts header metadata (first 100 lines),
+    tracks movement bounds from G0/G1 lines throughout, and captures
+    footer metadata (last 1000 lines).
     """
     estimated_time_seconds = 0
     filament_used_mm = 0.0
     filament_used_g: List[float] = []
     layer_count = None
 
-    def parse_time_from_line(line: str) -> Optional[int]:
-        lowered = line.lower()
+    min_x = min_y = min_z = float('inf')
+    max_x = max_y = max_z = float('-inf')
 
-        # Newer Orca/Snapmaker summaries (usually in header)
-        # Example: ; model printing time: 37m 15s; total estimated time: 37m 18s
-        total_est_match = re.search(r'total\s+estimated\s+time\s*:\s*([^;]+)', lowered)
-        if total_est_match:
-            return parse_time_to_seconds(total_est_match.group(1).strip())
+    # Ring buffer for last 1000 lines (footer metadata)
+    footer_buf: List[str] = []
+    FOOTER_SIZE = 1000
+    line_num = 0
 
-        model_time_match = re.search(r'model\s+printing\s+time\s*:\s*([^;]+)', lowered)
-        if model_time_match:
-            return parse_time_to_seconds(model_time_match.group(1).strip())
-
-        # Older Orca summary style
-        if 'estimated printing time' in lowered and 'normal mode' in lowered:
-            value_match = re.search(r'=\s*(.+)$', line)
-            if value_match:
-                return parse_time_to_seconds(value_match.group(1).strip())
-
-        return None
-
-    # Read first 100 lines for header metadata (layer count)
     with open(gcode_path, 'r') as f:
-        for i, line in enumerate(f):
-            if i >= 100:
-                break
+        for line in f:
+            stripped = line.strip()
+            line_num += 1
 
-            line = line.strip()
+            # ── Header metadata (first 100 lines) ────────
+            if line_num <= 100:
+                if 'total layer number' in stripped.lower():
+                    layers_match = re.search(r':\s*(\d+)', stripped)
+                    if layers_match:
+                        layer_count = int(layers_match.group(1))
 
-            # Extract layer count (appears as "total layer number: 100")
-            if 'total layer number' in line.lower():
-                layers_match = re.search(r':\s*(\d+)', line)
-                if layers_match:
-                    layer_count = int(layers_match.group(1))
+                parsed_time = _parse_time_from_line(stripped)
+                if parsed_time is not None:
+                    estimated_time_seconds = max(estimated_time_seconds, parsed_time)
 
-            # Try parse estimated time from header summary
-            parsed_time = parse_time_from_line(line)
-            if parsed_time is not None:
-                estimated_time_seconds = max(estimated_time_seconds, parsed_time)
+            # ── Movement bounds (G0/G1 lines throughout) ──
+            if stripped.startswith('G0 ') or stripped.startswith('G1 '):
+                x_match = re.search(r'X([\d.-]+)', stripped)
+                if x_match:
+                    x = float(x_match.group(1))
+                    if x < min_x: min_x = x
+                    if x > max_x: max_x = x
 
-    # Read last 1000 lines for footer metadata (time, filament)
-    # Orca Slicer puts summary metadata near the end, before CONFIG_BLOCK
-    with open(gcode_path, 'r') as f:
-        lines = f.readlines()
-        footer_lines = lines[-1000:] if len(lines) > 1000 else lines
+                y_match = re.search(r'Y([\d.-]+)', stripped)
+                if y_match:
+                    y = float(y_match.group(1))
+                    if y < min_y: min_y = y
+                    if y > max_y: max_y = y
 
-        for line in footer_lines:
-            line = line.strip()
+                z_match = re.search(r'Z([\d.-]+)', stripped)
+                if z_match:
+                    z = float(z_match.group(1))
+                    if z < min_z: min_z = z
+                    if z > max_z: max_z = z
 
-            # Extract estimated time
-            parsed_time = parse_time_from_line(line)
-            if parsed_time is not None:
-                estimated_time_seconds = max(estimated_time_seconds, parsed_time)
+            # ── Footer ring buffer ────────────────────────
+            footer_buf.append(stripped)
+            if len(footer_buf) > FOOTER_SIZE:
+                footer_buf.pop(0)
 
-            # Extract filament usage (specifically [mm] units)
-            # May be comma-separated for multicolour: ; filament used [mm] = 278.64, 284.92
-            elif 'filament used' in line.lower() and '[mm]' in line.lower():
-                mm_match = re.search(r'=\s*(.+)$', line)
-                if mm_match:
+    # ── Extract footer metadata ───────────────────────────
+    for stripped in footer_buf:
+        parsed_time = _parse_time_from_line(stripped)
+        if parsed_time is not None:
+            estimated_time_seconds = max(estimated_time_seconds, parsed_time)
+
+        elif 'filament used' in stripped.lower() and '[mm]' in stripped.lower():
+            mm_match = re.search(r'=\s*(.+)$', stripped)
+            if mm_match:
+                try:
                     values = [float(v.strip()) for v in mm_match.group(1).split(',') if v.strip()]
                     filament_used_mm = sum(values)
+                except ValueError:
+                    pass
 
-            # Extract per-filament weight in grams
-            # Example: ; filament used [g] = 0.83, 0.85
-            # Skip "total filament used [g]" which is the combined total
-            elif 'filament used' in line.lower() and '[g]' in line.lower() and 'total' not in line.lower():
-                g_match = re.search(r'=\s*(.+)$', line)
-                if g_match:
+        elif 'filament used' in stripped.lower() and '[g]' in stripped.lower() and 'total' not in stripped.lower():
+            g_match = re.search(r'=\s*(.+)$', stripped)
+            if g_match:
+                try:
                     filament_used_g = [float(v.strip()) for v in g_match.group(1).split(',') if v.strip()]
+                except ValueError:
+                    pass
 
-    # Extract movement bounds
-    bounds = extract_movement_bounds(gcode_path)
+    # Handle case where no movements found
+    if max_x == float('-inf'):
+        min_x = min_y = min_z = 0.0
+        max_x = max_y = max_z = 0.0
 
     return GCodeMetadata(
         estimated_time_seconds=estimated_time_seconds,
         filament_used_mm=filament_used_mm,
         layer_count=layer_count,
         filament_used_g=filament_used_g,
-        min_x=bounds['min_x'],
-        min_y=bounds['min_y'],
-        min_z=bounds['min_z'],
-        max_x=bounds['max_x'],
-        max_y=bounds['max_y'],
-        max_z=bounds['max_z']
+        min_x=min_x if min_x != float('inf') else 0.0,
+        min_y=min_y if min_y != float('inf') else 0.0,
+        min_z=min_z if min_z != float('inf') else 0.0,
+        max_x=max_x,
+        max_y=max_y,
+        max_z=max_z
     )
+
+
+def _parse_time_from_line(line: str) -> Optional[int]:
+    """Extract estimated time from a G-code comment line."""
+    lowered = line.lower()
+
+    # Newer Orca/Snapmaker summaries
+    total_est_match = re.search(r'total\s+estimated\s+time\s*:\s*([^;]+)', lowered)
+    if total_est_match:
+        return parse_time_to_seconds(total_est_match.group(1).strip())
+
+    model_time_match = re.search(r'model\s+printing\s+time\s*:\s*([^;]+)', lowered)
+    if model_time_match:
+        return parse_time_to_seconds(model_time_match.group(1).strip())
+
+    # Older Orca summary style
+    if 'estimated printing time' in lowered and 'normal mode' in lowered:
+        value_match = re.search(r'=\s*(.+)$', line)
+        if value_match:
+            return parse_time_to_seconds(value_match.group(1).strip())
+
+    return None
 
 
 def extract_movement_bounds(gcode_path: Path) -> Dict[str, float]:

--- a/apps/api/app/multi_plate_parser.py
+++ b/apps/api/app/multi_plate_parser.py
@@ -990,6 +990,99 @@ def _calculate_xml_bounds(file_path: Path,
     return result
 
 
+def calculate_all_bounds(file_path: Path,
+                         plates: List[PlateInfo]) -> Dict[str, Any]:
+    """Single-pass bounds computation for all plates + combined.
+
+    Opens the ZIP once, scans vertex bounds for every build item, and returns
+    both per-plate and combined bounds in a single pass.  Also returns the
+    number of geometry-bearing objects found (replaces separate parse_3mf call).
+
+    Returns:
+        {
+            "combined": {"min": [...], "max": [...], "size": [...]},
+            "per_plate": {
+                plate_id: {"min": [...], "max": [...], "size": [...]},
+                ...
+            },
+            "objects_count": int,
+        }
+    """
+    is_multi_plate = len(plates) > 1
+
+    ns = {
+        "m": "http://schemas.microsoft.com/3dmanufacturing/core/2015/02",
+        "p": "http://schemas.microsoft.com/3dmanufacturing/production/2015/06"
+    }
+
+    with zipfile.ZipFile(file_path, "r") as zf:
+        model_xml = zf.read("3D/3dmodel.model")
+        root = ET.fromstring(model_xml)
+
+        resources = root.find("m:resources", ns)
+        if resources is None:
+            raise ValueError("3MF missing resources section")
+
+        # Build object_id -> element map
+        obj_map: Dict[str, Any] = {}
+        for obj in resources.findall("m:object", ns):
+            oid = obj.get("id")
+            if oid:
+                obj_map[oid] = obj
+
+        build = root.find("m:build", ns)
+        items = build.findall("m:item", ns) if build is not None else []
+
+        # Scan all items in one pass, accumulating per-plate bounds
+        combined_min = [float('inf')] * 3
+        combined_max = [float('-inf')] * 3
+        per_plate_bounds: Dict[int, Dict[str, list]] = {}
+        objects_count = 0
+
+        for idx, item in enumerate(items):
+            plate_id = idx + 1
+            obj_id = item.get("objectid")
+            if not obj_id or obj_id not in obj_map:
+                continue
+
+            bounds = _scan_object_bounds(zf, obj_map[obj_id], ns)
+            if bounds is None:
+                continue
+
+            objects_count += 1
+            bmin, bmax = bounds
+            item_t = _parse_3mf_transform_values(item.get("transform", ""))
+            tbmin, tbmax = _apply_affine_to_bounds_3x4(bmin, bmax, item_t)
+
+            # Update combined bounds
+            for i in range(3):
+                if tbmin[i] < combined_min[i]:
+                    combined_min[i] = tbmin[i]
+                if tbmax[i] > combined_max[i]:
+                    combined_max[i] = tbmax[i]
+
+            # Store per-plate bounds
+            per_plate_bounds[plate_id] = {
+                "min": list(tbmin),
+                "max": list(tbmax),
+                "size": [tbmax[i] - tbmin[i] for i in range(3)],
+            }
+
+    if not per_plate_bounds:
+        combined_min = [0.0, 0.0, 0.0]
+        combined_max = [0.0, 0.0, 0.0]
+
+    return {
+        "combined": {
+            "min": combined_min,
+            "max": combined_max,
+            "size": [combined_max[i] - combined_min[i] for i in range(3)],
+        },
+        "per_plate": per_plate_bounds,
+        "objects_count": objects_count,
+    }
+
+
 def get_plate_bounds(file_path: Path,
                      plate_id: Optional[int] = None,
                      plates: Optional[List[PlateInfo]] = None) -> Dict[str, Any]:

--- a/apps/api/app/parser_3mf.py
+++ b/apps/api/app/parser_3mf.py
@@ -835,3 +835,515 @@ def extract_3mf_metadata_batch(file_path: Path) -> Dict[str, Any]:
         pass
 
     return result
+
+
+import re as _re_module  # for preview asset indexing
+
+
+def extract_upload_metadata(file_path: Path) -> Dict[str, Any]:
+    """Single-pass extraction of ALL upload-processing metadata from a 3MF.
+
+    Opens the ZIP once and gathers everything that _process_3mf_sync needs:
+    colors, per-plate colors, print settings, preview asset index, and the
+    Bambu Z-offset artifact flag.  Replaces 6+ separate function calls that
+    each opened the ZIP independently.
+
+    Returns dict with:
+        detected_colors: List[str]          — hex color codes
+        colors_per_plate: Dict[int, List[str]]
+        print_settings: Dict[str, Any]
+        preview_assets: {"by_plate": {...}, "best": str|None}
+        has_bambu_z_offset: bool            — source_offset_z present in model_settings
+    """
+    result: Dict[str, Any] = {
+        "detected_colors": [],
+        "colors_per_plate": {},
+        "print_settings": {},
+        "preview_assets": {"by_plate": {}, "best": None},
+        "has_bambu_z_offset": False,
+    }
+
+    try:
+        with zipfile.ZipFile(file_path, "r") as zf:
+            names = set(zf.namelist())
+
+            # ── Shared data loaded once ────────────────────────────
+            project_settings = None
+            if "Metadata/project_settings.config" in names:
+                try:
+                    project_settings = json.loads(zf.read("Metadata/project_settings.config"))
+                except (ValueError, KeyError):
+                    pass
+
+            model_settings_root = None
+            has_source_offset_z = False
+            if "Metadata/model_settings.config" in names:
+                try:
+                    model_settings_root = ET.fromstring(zf.read("Metadata/model_settings.config"))
+                    has_source_offset_z = any(
+                        m.get("key") == "source_offset_z"
+                        for m in model_settings_root.findall(".//metadata")
+                    )
+                except ET.ParseError:
+                    pass
+
+            result["has_bambu_z_offset"] = (
+                has_source_offset_z
+                and project_settings is not None
+            )
+
+            # ── Assigned extruders (from model_settings) ──────────
+            assigned_extruders: List[int] = []
+            if model_settings_root is not None:
+                exts_set: set = set()
+                for meta in model_settings_root.findall('.//metadata'):
+                    if meta.get('key') == 'extruder':
+                        raw = (meta.get('value') or '').strip()
+                        if raw:
+                            try:
+                                idx = int(raw)
+                                if idx > 0:
+                                    exts_set.add(idx)
+                            except ValueError:
+                                pass
+                assigned_extruders = sorted(exts_set)
+
+            # ── Layer tool changes ────────────────────────────────
+            layer_changes: Dict[int, List[Dict[str, Any]]] = {}
+            if 'Metadata/custom_gcode_per_layer.xml' in names:
+                try:
+                    cg_root = ET.fromstring(zf.read('Metadata/custom_gcode_per_layer.xml'))
+                    for plate_el in cg_root.findall("plate"):
+                        p_id = 0
+                        info = plate_el.find("plate_info")
+                        if info is not None:
+                            try:
+                                p_id = int(info.get("id", "0"))
+                            except ValueError:
+                                pass
+                        changes: List[Dict[str, Any]] = []
+                        for layer in plate_el.findall("layer"):
+                            if layer.get("type") != "2":
+                                continue
+                            try:
+                                z = float(layer.get("top_z", "0"))
+                            except ValueError:
+                                z = 0.0
+                            try:
+                                ext = int(layer.get("extruder", "1"))
+                            except ValueError:
+                                ext = 1
+                            color = layer.get("color", "")
+                            changes.append({"z": z, "extruder": ext, "color": color})
+                        if changes and p_id > 0:
+                            layer_changes[p_id] = changes
+                except ET.ParseError:
+                    pass
+
+            # ── Paint data detection (chunked scan) ───────────────
+            has_paint = False
+            MAX_SCAN = 32 * 1024 * 1024
+            CHUNK = 1024 * 1024
+            needles = (b"paint_color", b"mmu_segmentation")
+            for name in names:
+                if not name.endswith(".model"):
+                    continue
+                try:
+                    scanned = 0
+                    with zf.open(name) as f:
+                        while scanned < MAX_SCAN:
+                            chunk = f.read(CHUNK)
+                            if not chunk:
+                                break
+                            for needle in needles:
+                                if needle in chunk:
+                                    has_paint = True
+                                    break
+                            if has_paint:
+                                break
+                            scanned += len(chunk)
+                except Exception:
+                    pass
+                if has_paint:
+                    break
+
+            # ── Filament colours from project_settings ────────────
+            filament_colors: List[str] = []
+            if project_settings:
+                fc = project_settings.get("filament_colour", [])
+                if isinstance(fc, list):
+                    filament_colors = fc
+
+            # ── Detect colors (consolidated from detect_colors_from_3mf) ──
+            detected_colors: List[str] = []
+
+            # Try filament_sequence.json first
+            if 'Metadata/filament_sequence.json' in names:
+                try:
+                    seq = json.loads(zf.read('Metadata/filament_sequence.json'))
+                    if "filament_info" in seq:
+                        for filament in seq["filament_info"]:
+                            color = filament.get("color", "#FFFFFF")
+                            if not color.startswith("#"):
+                                color = "#" + color
+                            detected_colors.append(color)
+                    for plate_name, plate_data in seq.items():
+                        if isinstance(plate_data, dict) and "sequence" in plate_data:
+                            for filament in plate_data["sequence"]:
+                                color = filament.get("color", "#FFFFFF")
+                                if not color.startswith("#"):
+                                    color = "#" + color
+                                detected_colors.append(color)
+                except (KeyError, ValueError):
+                    pass
+
+            # Paint data → return all filament colors
+            if filament_colors and len(filament_colors) > 1 and has_paint:
+                active = [c for c in filament_colors if c]
+                if active:
+                    detected_colors = active
+
+            # Layer tool changes → map used extruders to colors
+            elif layer_changes and filament_colors:
+                ext_indices: set = {1}
+                for changes in layer_changes.values():
+                    for ch in changes:
+                        ext_indices.add(ch.get("extruder", 1))
+                active = _extruders_to_colors(ext_indices, filament_colors)
+                if len(active) > 1:
+                    detected_colors = active
+
+            # Assigned extruders → map to colors
+            elif assigned_extruders and filament_colors:
+                active = []
+                for ext in assigned_extruders:
+                    idx = ext - 1
+                    if 0 <= idx < len(filament_colors):
+                        c = filament_colors[idx]
+                        if c and c not in active:
+                            active.append(c)
+                if active:
+                    detected_colors = active
+
+            # Fallback: extruder_colour / filament_colour from project_settings
+            if not detected_colors and project_settings:
+                for key in ("extruder_colour", "filament_colour"):
+                    vals = project_settings.get(key, [])
+                    if isinstance(vals, list):
+                        for c in vals:
+                            if c and c not in detected_colors:
+                                detected_colors.append(c)
+
+            # PrusaSlicer fallback
+            if not detected_colors:
+                try:
+                    pe_data = zf.read("Metadata/Slic3r_PE.config").decode("utf-8", errors="replace")
+                    pe_extruder_colours: List[str] = []
+                    for line in pe_data.splitlines():
+                        stripped = line.lstrip("; ").strip()
+                        if stripped.startswith("extruder_colour"):
+                            _, _, value = stripped.partition("=")
+                            value = value.strip()
+                            if value:
+                                pe_extruder_colours = [c.strip() for c in value.split(";") if c.strip()]
+                            break
+                    if pe_extruder_colours:
+                        if has_paint:
+                            detected_colors = pe_extruder_colours
+                        else:
+                            try:
+                                model_cfg = zf.read("Metadata/Slic3r_PE_model.config").decode("utf-8", errors="replace")
+                                model_cfg_root = ET.fromstring(model_cfg)
+                                pe_assigned: set = set()
+                                for meta in model_cfg_root.findall('.//metadata'):
+                                    if meta.get('key') == 'extruder' and meta.get('type') == 'object':
+                                        raw = (meta.get('value') or '').strip()
+                                        if raw:
+                                            try:
+                                                pe_assigned.add(int(raw))
+                                            except ValueError:
+                                                pass
+                                if len(pe_assigned) > 1:
+                                    detected_colors = _extruders_to_colors(pe_assigned, pe_extruder_colours)
+                            except (KeyError, ET.ParseError):
+                                pass
+                except KeyError:
+                    pass
+
+            # Deduplicate
+            seen: set = set()
+            unique: List[str] = []
+            for c in detected_colors:
+                if c not in seen:
+                    seen.add(c)
+                    unique.append(c)
+            result["detected_colors"] = unique
+
+            # ── Per-plate colors (consolidated from detect_colors_per_plate) ──
+            colors_per_plate: Dict[int, List[str]] = {}
+            if filament_colors:
+                num_extruders = 2
+                if project_settings:
+                    ext_colours = project_settings.get("extruder_colour", [])
+                    if isinstance(ext_colours, list) and len(ext_colours) >= 2:
+                        num_extruders = len(ext_colours)
+
+                # Source 1: Layer tool changes
+                source1: Dict[int, List[str]] = {}
+                if layer_changes:
+                    for pid, changes in layer_changes.items():
+                        ext_indices = {1}
+                        for ch in changes:
+                            ext_indices.add(ch.get("extruder", 1))
+                        plate_colors = _extruders_to_colors(ext_indices, filament_colors)
+                        if plate_colors:
+                            source1[pid] = plate_colors
+
+                # Source 2: Per-object/part extruder from model_settings
+                source2: Dict[int, List[str]] = {}
+                if model_settings_root is not None:
+                    obj_extruders: Dict[str, set] = {}
+                    for obj_elem in model_settings_root.findall("object"):
+                        oid = obj_elem.get("id")
+                        if not oid:
+                            continue
+                        exts: set = set()
+                        ext_meta = obj_elem.find("metadata[@key='extruder']")
+                        if ext_meta is not None:
+                            try:
+                                exts.add(int(ext_meta.get("value", "1")))
+                            except ValueError:
+                                pass
+                        for part in obj_elem.findall("part"):
+                            part_ext = part.find("metadata[@key='extruder']")
+                            if part_ext is not None:
+                                try:
+                                    exts.add(int(part_ext.get("value", "1")))
+                                except ValueError:
+                                    pass
+                        if exts:
+                            obj_extruders[oid] = exts
+
+                    # Map objects to plates via build items
+                    try:
+                        model_xml = zf.read("3D/3dmodel.model")
+                        root = ET.fromstring(model_xml)
+                        mns = {"m": "http://schemas.microsoft.com/3dmanufacturing/core/2015/02"}
+                        build = root.find("m:build", mns)
+                        if build is not None:
+                            for i, item in enumerate(build.findall("m:item", mns)):
+                                pid = i + 1
+                                obj_id = item.get("objectid", "")
+                                exts = obj_extruders.get(obj_id, {1})
+                                plate_colors = _extruders_to_colors(exts, filament_colors)
+                                if plate_colors:
+                                    source2[pid] = plate_colors
+                    except (KeyError, ET.ParseError):
+                        pass
+
+                # Source 3: Wipe tower in plate_N.json
+                wipe_tower_plates: set = set()
+                for name in names:
+                    if not name.startswith("Metadata/plate_") or not name.endswith(".json"):
+                        continue
+                    try:
+                        plate_data = json.loads(zf.read(name))
+                        bbox_objects = plate_data.get("bbox_objects", [])
+                        has_wipe = any(o.get("name") == "wipe_tower" for o in bbox_objects)
+                        if has_wipe:
+                            num_str = name.split("plate_")[1].split(".")[0]
+                            wipe_tower_plates.add(int(num_str))
+                    except Exception:
+                        pass
+
+                # Merge sources
+                all_plate_ids = set(source1.keys()) | set(source2.keys()) | wipe_tower_plates
+                for pid in all_plate_ids:
+                    s1 = source1.get(pid, [])
+                    s2 = source2.get(pid, [])
+                    if len(s2) >= 2:
+                        colors_per_plate[pid] = s2
+                    elif len(s1) >= 2:
+                        colors_per_plate[pid] = s1
+                    elif s2:
+                        colors_per_plate[pid] = s2
+                    elif s1:
+                        colors_per_plate[pid] = s1
+
+                    if pid in wipe_tower_plates and len(colors_per_plate.get(pid, [])) < 2:
+                        multi = _extruders_to_colors(set(range(1, num_extruders + 1)), filament_colors)
+                        if len(multi) >= 2:
+                            colors_per_plate[pid] = multi
+
+            result["colors_per_plate"] = colors_per_plate
+
+            # ── Print settings (consolidated from detect_print_settings) ──
+            if project_settings:
+                settings = _extract_print_settings_from_config(project_settings)
+                result["print_settings"] = settings
+
+            # ── Preview assets (consolidated from _index_preview_assets) ──
+            preview_map: Dict[int, str] = {}
+            best_preview = None
+            image_names = [
+                n for n in names
+                if n.lower().endswith((".png", ".jpg", ".jpeg", ".webp"))
+                and "/metadata/" in f"/{n.lower()}"
+            ]
+            for img_name in image_names:
+                lower = img_name.lower()
+                match = _re_module.search(r"(?:plate|top|pick|thumbnail|preview|cover)[_\-]?(\d+)", lower)
+                if not match:
+                    match = _re_module.search(r"[_\-/](\d+)\.(?:png|jpg|jpeg|webp)$", lower)
+                if not match:
+                    continue
+                pid = int(match.group(1))
+                if pid not in preview_map:
+                    preview_map[pid] = img_name
+
+            if image_names:
+                def _score(path: str):
+                    p = path.lower()
+                    for i, kw in enumerate(["thumbnail", "preview", "cover", "top", "plate", "pick"]):
+                        if kw in p:
+                            return (i, len(p))
+                    return (9, len(p))
+                best_preview = sorted(image_names, key=_score)[0]
+
+            result["preview_assets"] = {"by_plate": preview_map, "best": best_preview}
+
+    except Exception:
+        pass
+
+    return result
+
+
+def _extract_print_settings_from_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract print settings from a parsed project_settings.config dict.
+
+    Pure function — no file I/O.  Shared by both extract_upload_metadata()
+    and the standalone detect_print_settings().
+    """
+    settings: Dict[str, Any] = {}
+
+    def _as_bool(val) -> bool:
+        return str(val).strip() in ("1", "true", "True")
+
+    def _as_int(val):
+        try:
+            return int(float(str(val)))
+        except (ValueError, TypeError):
+            return None
+
+    def _as_float(val, decimals=2):
+        try:
+            return round(float(str(val)), decimals)
+        except (ValueError, TypeError):
+            return None
+
+    def _first_element(val):
+        if isinstance(val, list) and val:
+            return val[0]
+        return val
+
+    # support
+    raw = config.get("enable_support")
+    if raw is not None:
+        settings["enable_support"] = _as_bool(raw)
+    raw = config.get("support_type")
+    if raw is not None and str(raw).strip():
+        settings["support_type"] = str(raw).strip()
+    raw = config.get("support_threshold_angle")
+    if raw is not None:
+        v = _as_int(raw)
+        if v is not None:
+            settings["support_threshold_angle"] = v
+
+    # brim
+    raw = config.get("brim_type")
+    if raw is not None and str(raw).strip():
+        settings["brim_type"] = str(raw).strip()
+    raw = config.get("brim_width")
+    if raw is not None:
+        v = _as_float(raw)
+        if v is not None:
+            settings["brim_width"] = v
+    raw = config.get("brim_object_gap")
+    if raw is not None:
+        v = _as_float(raw)
+        if v is not None:
+            settings["brim_object_gap"] = v
+
+    # skirt
+    raw = config.get("skirt_loops")
+    if raw is not None:
+        v = _as_int(raw)
+        if v is not None:
+            settings["skirt_loops"] = v
+    raw = config.get("skirt_distance")
+    if raw is not None:
+        v = _as_float(raw)
+        if v is not None:
+            settings["skirt_distance"] = v
+    raw = config.get("skirt_height")
+    if raw is not None:
+        v = _as_int(raw)
+        if v is not None:
+            settings["skirt_height"] = v
+
+    # wall / infill / layer
+    raw = config.get("wall_loops")
+    if raw is not None:
+        v = _as_int(raw)
+        if v is not None:
+            settings["wall_loops"] = v
+    raw = config.get("sparse_infill_density")
+    if raw is not None:
+        v = _as_int(str(raw).replace("%", ""))
+        if v is not None:
+            settings["sparse_infill_density"] = v
+    raw = config.get("sparse_infill_pattern")
+    if raw is not None and str(raw).strip():
+        settings["sparse_infill_pattern"] = str(raw).strip()
+    raw = config.get("layer_height")
+    if raw is not None:
+        v = _as_float(raw)
+        if v is not None:
+            settings["layer_height"] = v
+
+    # prime tower
+    raw = config.get("enable_prime_tower")
+    if raw is not None:
+        settings["enable_prime_tower"] = _as_bool(raw)
+    raw = config.get("prime_tower_width")
+    if raw is not None:
+        v = _as_int(raw)
+        if v is not None:
+            settings["prime_tower_width"] = v
+    raw = config.get("prime_tower_brim_width")
+    if raw is not None:
+        v = _as_int(raw)
+        if v is not None and v >= 0:
+            settings["prime_tower_brim_width"] = v
+    raw = config.get("filament_prime_volume")
+    if raw is not None:
+        v = _as_int(_first_element(raw))
+        if v is not None:
+            settings["prime_volume"] = v
+
+    # temperature / bed
+    raw = config.get("nozzle_temperature")
+    if raw is not None:
+        v = _as_int(_first_element(raw))
+        if v is not None:
+            settings["nozzle_temperature"] = v
+    raw = config.get("bed_temperature")
+    if raw is not None:
+        v = _as_int(_first_element(raw))
+        if v is not None:
+            settings["bed_temperature"] = v
+    raw = config.get("curr_bed_type")
+    if raw is not None and str(raw).strip():
+        settings["curr_bed_type"] = str(raw).strip()
+
+    return settings

--- a/apps/api/app/plate_validator.py
+++ b/apps/api/app/plate_validator.py
@@ -164,6 +164,45 @@ class PlateValidator:
 
         return warnings
 
+    def validate_precomputed_bounds(self, bounds: dict,
+                                    is_multi_plate: bool = False,
+                                    is_bambu_z_offset: bool = False) -> dict:
+        """Validate pre-computed bounds against build volume (no file I/O).
+
+        Args:
+            bounds: {"min": [x,y,z], "max": [x,y,z], "size": [w,d,h]}
+            is_multi_plate: whether this is a multi-plate file
+            is_bambu_z_offset: whether Bambu source_offset_z artifact was detected
+
+        Returns:
+            {"bounds": ..., "warnings": [...], "fits": bool}
+        """
+        width = float(bounds['size'][0])
+        depth = float(bounds['size'][1])
+        height = float(bounds['size'][2])
+
+        build_volume_warnings = self._check_build_volume(width, depth, height)
+        warnings = list(build_volume_warnings)
+
+        # Check for objects below bed
+        if bounds['min'][2] < -0.001:
+            if is_bambu_z_offset and bounds['min'][2] >= -15.0:
+                logger.info(
+                    "Suppressing below-bed warning (Bambu source-offset artifact, Z_min=%.3f)",
+                    float(bounds['min'][2]),
+                )
+            else:
+                warnings.append(
+                    f"Warning: Objects extend below bed (Z_min = {bounds['min'][2]:.1f}mm). "
+                    "This may cause printing issues."
+                )
+
+        return {
+            "bounds": bounds,
+            "warnings": warnings,
+            "fits": len(build_volume_warnings) == 0,
+        }
+
     def _is_bambu_z_offset_artifact(self, file_path: Path, min_z: float) -> bool:
         """Heuristic for Bambu-exported files with metadata-induced negative Z.
 

--- a/apps/api/app/profile_embedder.py
+++ b/apps/api/app/profile_embedder.py
@@ -606,6 +606,99 @@ class ProfileEmbedder:
             pass
         return False
 
+    def _analyze_source_3mf(self, source_3mf: Path) -> Dict[str, Any]:
+        """Single-pass analysis of a source 3MF for embedding decisions.
+
+        Opens the ZIP once and returns all detection results that would
+        otherwise require 5-7 separate ZIP opens:
+        - is_bambu, has_multi_extruder_assignments, has_layer_tool_changes,
+          has_paint_data, is_multi_plate, assigned_extruder_count
+        """
+        result = {
+            "is_bambu": False,
+            "has_multi_extruder_assignments": False,
+            "has_layer_tool_changes": False,
+            "has_paint_data": False,
+            "is_multi_plate": False,
+            "assigned_extruder_count": 1,
+        }
+        try:
+            with zipfile.ZipFile(source_3mf, 'r') as zf:
+                names = set(zf.namelist())
+
+                # Bambu detection
+                bambu_markers = {
+                    'Metadata/model_settings.config',
+                    'Metadata/slice_info.config',
+                    'Metadata/filament_sequence.json'
+                }
+                result["is_bambu"] = bool(bambu_markers & names)
+
+                # Extruder assignments + count from model_settings.config
+                if 'Metadata/model_settings.config' in names:
+                    root = ET.fromstring(zf.read('Metadata/model_settings.config'))
+                    extruders = set()
+                    for meta in root.findall('.//metadata'):
+                        if meta.get('key') == 'extruder':
+                            raw = (meta.get('value') or '').strip()
+                            if raw:
+                                try:
+                                    idx = int(raw)
+                                    if idx > 0:
+                                        extruders.add(idx)
+                                except ValueError:
+                                    pass
+                    result["has_multi_extruder_assignments"] = len(extruders) > 1
+                    result["assigned_extruder_count"] = max(extruders) if extruders else 1
+
+                # Layer tool changes from custom_gcode_per_layer.xml
+                if 'Metadata/custom_gcode_per_layer.xml' in names:
+                    cg_root = ET.fromstring(zf.read('Metadata/custom_gcode_per_layer.xml'))
+                    for layer in cg_root.findall('.//layer'):
+                        if layer.get('type') == '2':
+                            result["has_layer_tool_changes"] = True
+                            break
+
+                # Multi-plate detection (count build items)
+                if '3D/3dmodel.model' in names:
+                    model_root = ET.fromstring(zf.read('3D/3dmodel.model'))
+                    mns = {"m": "http://schemas.microsoft.com/3dmanufacturing/core/2015/02"}
+                    build = model_root.find("m:build", mns)
+                    if build is not None:
+                        items = build.findall("m:item", mns)
+                        result["is_multi_plate"] = len(items) > 1
+
+                # Paint data scan (chunked, capped at 32 MB per .model file)
+                MAX_SCAN = 32 * 1024 * 1024
+                CHUNK = 1024 * 1024
+                needles = (b"paint_color", b"mmu_segmentation")
+                for name in names:
+                    if not name.endswith(".model"):
+                        continue
+                    try:
+                        scanned = 0
+                        with zf.open(name) as f:
+                            while scanned < MAX_SCAN:
+                                chunk = f.read(CHUNK)
+                                if not chunk:
+                                    break
+                                for needle in needles:
+                                    if needle in chunk:
+                                        result["has_paint_data"] = True
+                                        break
+                                if result["has_paint_data"]:
+                                    break
+                                scanned += len(chunk)
+                    except Exception:
+                        pass
+                    if result["has_paint_data"]:
+                        break
+
+        except Exception as e:
+            logger.warning(f"Failed to analyze source 3MF: {e}")
+
+        return result
+
     def _sanitize_wipe_tower_position(
         self,
         config: Dict[str, Any],
@@ -1093,22 +1186,36 @@ class ProfileEmbedder:
             profiles = self.load_snapmaker_profiles()
 
             preserve_model_settings_from = None
-            is_bambu = precomputed_is_bambu if precomputed_is_bambu is not None else self._is_bambu_file(source_3mf)
-            has_multi_assignments = precomputed_has_multi_assignments if precomputed_has_multi_assignments is not None else self._has_multi_extruder_assignments(source_3mf)
-            has_layer_changes = precomputed_has_layer_changes if precomputed_has_layer_changes is not None else self._has_layer_tool_changes(source_3mf)
+
+            # Single-pass analysis (1 ZIP open instead of 5-7)
+            if precomputed_is_bambu is not None:
+                # Use precomputed values if available
+                is_bambu = precomputed_is_bambu
+                has_multi_assignments = precomputed_has_multi_assignments if precomputed_has_multi_assignments is not None else False
+                has_layer_changes = precomputed_has_layer_changes if precomputed_has_layer_changes is not None else False
+                # Only do single-pass analysis for remaining checks
+                _need_extra = (not has_multi_assignments and not has_layer_changes and is_bambu)
+                if _need_extra:
+                    analysis = self._analyze_source_3mf(source_3mf)
+                    has_paint = analysis["has_paint_data"]
+                    is_multi_plate = analysis["is_multi_plate"]
+                else:
+                    has_paint = False
+                    is_multi_plate = False
+            else:
+                analysis = self._analyze_source_3mf(source_3mf)
+                is_bambu = analysis["is_bambu"]
+                has_multi_assignments = analysis["has_multi_extruder_assignments"]
+                has_layer_changes = analysis["has_layer_tool_changes"]
+                has_paint = analysis["has_paint_data"]
+                is_multi_plate = analysis["is_multi_plate"]
 
             needs_preserve = has_multi_assignments or has_layer_changes
             if not needs_preserve and is_bambu and requested_filament_count > 1:
-                needs_preserve = self._has_paint_data_zip(source_3mf)
-            if not needs_preserve and is_bambu:
-                try:
-                    from multi_plate_parser import parse_multi_plate_3mf as _parse_mp
-                    _, is_multi = _parse_mp(source_3mf)
-                    if is_multi:
-                        needs_preserve = True
-                        logger.info("Bambu multi-plate file detected — using preserve path to keep plate structure")
-                except Exception:
-                    pass
+                needs_preserve = has_paint
+            if not needs_preserve and is_bambu and is_multi_plate:
+                needs_preserve = True
+                logger.info("Bambu multi-plate file detected — using preserve path to keep plate structure")
 
             if is_bambu and needs_preserve:
                 reason = (

--- a/apps/api/app/routes_slice.py
+++ b/apps/api/app/routes_slice.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import FileResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
-from typing import Optional, List, Dict, Tuple
+from typing import Any, Optional, List, Dict, Tuple
 
 from db import get_pg_pool
 from config import get_printer_profile
@@ -39,6 +39,12 @@ router = APIRouter(tags=["slicing"])
 logger = logging.getLogger(__name__)
 INT32_MAX = 2_147_483_647
 
+# Module-level compiled regex patterns for G-code parsing (avoid per-call recompilation)
+_RE_GCODE_COORD = re.compile(r'([XYZ])([\d.-]+)')
+_RE_GCODE_FIELDS = re.compile(r'([GXYZEF])([\d.-]+)')
+_RE_LAYER_CHANGE = re.compile(r'^;\s*(LAYER_CHANGE|CHANGE_LAYER)\b', re.IGNORECASE)
+_RE_LAYER_NUMBER = re.compile(r'^;\s*LAYER\s*:\s*(\d+)\b', re.IGNORECASE)
+
 # ---------------------------------------------------------------------------
 # In-memory progress store for active slicing jobs.
 # Keys are job_id strings.  Values: {"progress": 0-100, "message": str}
@@ -59,16 +65,80 @@ def _clear_progress(job_id: str):
     _job_progress.pop(job_id, None)
 
 
-def _get_bambu_plate_for_object(source_3mf: Path, object_id: str) -> Optional[int]:
+def _load_bambu_plate_metadata(source_3mf: Path) -> Optional[Dict[str, Any]]:
+    """Single-pass extraction of all Bambu plate metadata.
+
+    Opens the ZIP once and returns all plate mapping info needed by the
+    slice-plate route, replacing 4-5 separate ZIP opens.
+
+    Returns None if not a Bambu file. Otherwise returns:
+        {
+            "object_to_plater": {object_id_str: plater_id_int},
+            "plater_to_objects": {plater_id_int: [object_id_str, ...]},
+            "oid_to_build_idx": {object_id_str: build_item_index_1based},
+        }
+    """
+    try:
+        import xml.etree.ElementTree as ET
+        with zipfile.ZipFile(source_3mf, 'r') as zf:
+            if 'Metadata/model_settings.config' not in zf.namelist():
+                return None
+
+            # Parse model_settings.config for plate→object mappings
+            ms_root = ET.fromstring(zf.read('Metadata/model_settings.config'))
+            object_to_plater: Dict[str, int] = {}
+            plater_to_objects: Dict[int, List[str]] = {}
+            for plate in ms_root.findall('.//plate'):
+                plater_id = None
+                for meta in plate.findall('metadata'):
+                    if meta.get('key') == 'plater_id':
+                        try:
+                            plater_id = int(meta.get('value'))
+                        except (TypeError, ValueError):
+                            pass
+                if plater_id is None:
+                    continue
+                plate_oids: List[str] = []
+                for mi in plate.findall('model_instance'):
+                    for m in mi.findall('metadata'):
+                        if m.get('key') == 'object_id':
+                            oid = str(m.get('value'))
+                            object_to_plater[oid] = plater_id
+                            plate_oids.append(oid)
+                if plate_oids:
+                    plater_to_objects[plater_id] = plate_oids
+
+            # Build object_id → build_item_index map from model XML
+            oid_to_build_idx: Dict[str, int] = {}
+            if '3D/3dmodel.model' in zf.namelist():
+                model_root = ET.fromstring(zf.read('3D/3dmodel.model'))
+                ns_3mf = "http://schemas.microsoft.com/3dmanufacturing/core/2015/02"
+                build = model_root.find(f"{{{ns_3mf}}}build")
+                if build is not None:
+                    for i, item in enumerate(build.findall(f"{{{ns_3mf}}}item"), start=1):
+                        oid = item.get("objectid")
+                        if oid:
+                            oid_to_build_idx[oid] = i
+
+            return {
+                "object_to_plater": object_to_plater,
+                "plater_to_objects": plater_to_objects,
+                "oid_to_build_idx": oid_to_build_idx,
+            }
+    except Exception as e:
+        logger.warning(f"Could not load Bambu plate metadata: {e}")
+        return None
+
+
+def _get_bambu_plate_for_object(source_3mf: Path, object_id: str,
+                                preloaded: Optional[Dict] = None) -> Optional[int]:
     """Look up the Bambu plater_id that contains the given object_id.
 
-    Bambu Studio stores plate→object mappings in model_settings.config as
-    <plate> elements containing <model_instance> entries with object_id values.
-    Our multi_plate_parser maps build <item> indices to "plates", which differ
-    from Bambu's plater_id numbering in multi-plate files.
-
-    Returns the plater_id (1-indexed) or None if not found.
+    If `preloaded` is provided (from _load_bambu_plate_metadata), avoids ZIP open.
     """
+    if preloaded is not None:
+        return preloaded["object_to_plater"].get(str(object_id))
+
     try:
         import xml.etree.ElementTree as ET
         with zipfile.ZipFile(source_3mf, 'r') as zf:
@@ -89,12 +159,15 @@ def _get_bambu_plate_for_object(source_3mf: Path, object_id: str) -> Optional[in
     return None
 
 
-def _get_bambu_plate_object_ids(source_3mf: Path, plater_id: int) -> List[str]:
+def _get_bambu_plate_object_ids(source_3mf: Path, plater_id: int,
+                                preloaded: Optional[Dict] = None) -> List[str]:
     """Return all object_ids assigned to the given Bambu plater_id.
 
-    Used to expand a single-object transform to all co-objects on the same
-    Bambu plate so they move as a group and don't collide.
+    If `preloaded` is provided (from _load_bambu_plate_metadata), avoids ZIP open.
     """
+    if preloaded is not None:
+        return preloaded["plater_to_objects"].get(plater_id, [])
+
     result: List[str] = []
     try:
         import xml.etree.ElementTree as ET
@@ -117,12 +190,34 @@ def _get_bambu_plate_object_ids(source_3mf: Path, plater_id: int) -> List[str]:
     return result
 
 
-def _get_bambu_co_plate_indices(source_3mf: Path, plate_id: int) -> Optional[List[int]]:
+def _get_bambu_co_plate_indices(source_3mf: Path, plate_id: int,
+                                preloaded: Optional[Dict] = None) -> Optional[List[int]]:
     """Return all build_item indices sharing the same Bambu plate as `plate_id`.
 
-    Returns None if not a Bambu file or no model_settings.config found.
-    Returns a list of 1-based build_item indices (including `plate_id` itself).
+    If `preloaded` is provided (from _load_bambu_plate_metadata), avoids all ZIP opens.
     """
+    if preloaded is not None:
+        oid_to_idx = preloaded["oid_to_build_idx"]
+        items_count = max(oid_to_idx.values()) if oid_to_idx else 0
+        if plate_id < 1 or plate_id > items_count:
+            return None
+        # Find the object_id for the requested plate_id
+        target_oid = None
+        for oid, idx in oid_to_idx.items():
+            if idx == plate_id:
+                target_oid = oid
+                break
+        if not target_oid:
+            return None
+        bambu_pid = preloaded["object_to_plater"].get(target_oid)
+        if bambu_pid is None:
+            return None
+        co_oids = preloaded["plater_to_objects"].get(bambu_pid, [])
+        if len(co_oids) <= 1:
+            return None
+        co_indices = sorted(oid_to_idx[oid] for oid in co_oids if oid in oid_to_idx)
+        return co_indices if len(co_indices) > 1 else None
+
     try:
         import xml.etree.ElementTree as ET
         with zipfile.ZipFile(source_3mf, 'r') as zf:
@@ -1876,7 +1971,13 @@ async def slice_upload(upload_id: int, request: SliceRequest):
                     layer_count = $7,
                     three_mf_path = $8,
                     filament_colors = $9,
-                    filament_used_g = $10
+                    filament_used_g = $10,
+                    gcode_bounds_min_x = $11,
+                    gcode_bounds_min_y = $12,
+                    gcode_bounds_min_z = $13,
+                    gcode_bounds_max_x = $14,
+                    gcode_bounds_max_y = $15,
+                    gcode_bounds_max_z = $16
                 WHERE job_id = $1 AND status = 'processing'
                 """,
                 job_id,
@@ -1888,7 +1989,13 @@ async def slice_upload(upload_id: int, request: SliceRequest):
                 metadata.get('layer_count'),
                 str(embedded_3mf),
                 filament_colors_json,
-                filament_used_g_json
+                filament_used_g_json,
+                metadata.get('min_x', 0.0),
+                metadata.get('min_y', 0.0),
+                metadata.get('min_z', 0.0),
+                metadata.get('max_x', 0.0),
+                metadata.get('max_y', 0.0),
+                metadata.get('max_z', 0.0),
             )
             if result_tag == "UPDATE 0":
                 job_logger.info(f"Job {job_id} was cancelled before completion could be recorded")
@@ -2604,7 +2711,13 @@ async def slice_plate(upload_id: int, request: SlicePlateRequest):
                     layer_count = $7,
                     three_mf_path = $8,
                     filament_colors = $9,
-                    filament_used_g = $10
+                    filament_used_g = $10,
+                    gcode_bounds_min_x = $11,
+                    gcode_bounds_min_y = $12,
+                    gcode_bounds_min_z = $13,
+                    gcode_bounds_max_x = $14,
+                    gcode_bounds_max_y = $15,
+                    gcode_bounds_max_z = $16
                 WHERE job_id = $1 AND status = 'processing'
                 """,
                 job_id,
@@ -2616,7 +2729,13 @@ async def slice_plate(upload_id: int, request: SlicePlateRequest):
                 metadata.get('layer_count'),
                 str(embedded_3mf),
                 filament_colors_json,
-                filament_used_g_json
+                filament_used_g_json,
+                metadata.get('min_x', 0.0),
+                metadata.get('min_y', 0.0),
+                metadata.get('min_z', 0.0),
+                metadata.get('max_x', 0.0),
+                metadata.get('max_y', 0.0),
+                metadata.get('max_z', 0.0),
             )
             if result_tag == "UPDATE 0":
                 job_logger.info(f"Job {job_id} was cancelled before completion could be recorded")
@@ -2893,7 +3012,8 @@ async def get_upload_layout(upload_id: int, plate_id: Optional[int] = Query(None
         # so the placement viewer shows the full plate group, not just one item.
         effective_plate_ids = None
         if plate_id is not None:
-            co_indices = _get_bambu_co_plate_indices(source_3mf, plate_id)
+            bambu_meta = _load_bambu_plate_metadata(source_3mf)
+            co_indices = _get_bambu_co_plate_indices(source_3mf, plate_id, preloaded=bambu_meta)
             if co_indices:
                 effective_plate_ids = co_indices
 
@@ -2990,7 +3110,8 @@ async def get_upload_geometry(
     # so the placement viewer shows the full plate group geometry.
     effective_plate_ids = None
     if plate_id is not None and build_item_index is None:
-        co_indices = _get_bambu_co_plate_indices(source_3mf, plate_id)
+        bambu_meta = await asyncio.to_thread(_load_bambu_plate_metadata, source_3mf)
+        co_indices = _get_bambu_co_plate_indices(source_3mf, plate_id, preloaded=bambu_meta)
         if co_indices:
             effective_plate_ids = co_indices
 
@@ -3024,20 +3145,82 @@ async def get_upload_geometry(
         raise HTTPException(status_code=500, detail=f"Failed to load geometry: {str(e)}")
 
 
+# In-memory preview cache: (upload_id, plate_id_or_"best") → (image_bytes, media_type)
+# Small footprint (thumbnails are typically <100 KB each).
+_preview_cache: Dict[Tuple[int, str], Tuple[bytes, str]] = {}
+
+
+def _get_cached_preview(upload_id: int, plate_key: str, source_3mf: Path) -> Optional[Tuple[bytes, str]]:
+    """Return cached (image_bytes, media_type) or extract from ZIP and cache."""
+    cache_key = (upload_id, plate_key)
+    if cache_key in _preview_cache:
+        return _preview_cache[cache_key]
+
+    # Single ZIP open: index + extract in one shot
+    try:
+        with zipfile.ZipFile(source_3mf, "r") as zf:
+            names = zf.namelist()
+            image_names = [
+                n for n in names
+                if n.lower().endswith((".png", ".jpg", ".jpeg", ".webp"))
+                and "/metadata/" in f"/{n.lower()}"
+            ]
+
+            if plate_key == "best":
+                if not image_names:
+                    return None
+                def _score(path: str):
+                    p = path.lower()
+                    for i, kw in enumerate(["thumbnail", "preview", "cover", "top", "plate", "pick"]):
+                        if kw in p:
+                            return (i, len(p))
+                    return (9, len(p))
+                internal_path = sorted(image_names, key=_score)[0]
+            else:
+                pid = int(plate_key)
+                preview_map: Dict[int, str] = {}
+                for img_name in image_names:
+                    lower = img_name.lower()
+                    match = re.search(r"(?:plate|top|pick|thumbnail|preview|cover)[_\-]?(\d+)", lower)
+                    if not match:
+                        match = re.search(r"[_\-/](\d+)\.(?:png|jpg|jpeg|webp)$", lower)
+                    if match:
+                        img_pid = int(match.group(1))
+                        if img_pid not in preview_map:
+                            preview_map[img_pid] = img_name
+
+                internal_path = preview_map.get(pid)
+                if not internal_path and pid == 1:
+                    # Fallback to best generic preview for plate 1
+                    if image_names:
+                        def _score(path: str):
+                            p = path.lower()
+                            for i, kw in enumerate(["thumbnail", "preview", "cover", "top", "plate", "pick"]):
+                                if kw in p:
+                                    return (i, len(p))
+                            return (9, len(p))
+                        internal_path = sorted(image_names, key=_score)[0]
+
+                if not internal_path:
+                    return None
+
+            image_bytes = zf.read(internal_path)
+            media_type = _guess_image_media_type(internal_path)
+            _preview_cache[cache_key] = (image_bytes, media_type)
+            return (image_bytes, media_type)
+    except Exception:
+        return None
+
+
 @router.get("/uploads/{upload_id}/plates/{plate_id}/preview")
 async def get_upload_plate_preview(upload_id: int, plate_id: int):
     """Return embedded preview image for a specific plate when available."""
     pool = get_pg_pool()
     async with pool.acquire() as conn:
         upload = await conn.fetchrow(
-            """
-            SELECT id, file_path
-            FROM uploads
-            WHERE id = $1
-            """,
+            "SELECT id, file_path FROM uploads WHERE id = $1",
             upload_id,
         )
-
         if not upload:
             raise HTTPException(status_code=404, detail="Upload not found")
 
@@ -3045,24 +3228,11 @@ async def get_upload_plate_preview(upload_id: int, plate_id: int):
     if not source_3mf.exists():
         raise HTTPException(status_code=404, detail="Source 3MF file not found")
 
-    assets = _index_preview_assets(source_3mf)
-    by_plate_obj = assets.get("by_plate")
-    preview_map: Dict[int, str] = by_plate_obj if isinstance(by_plate_obj, dict) else {}
-    internal_path = preview_map.get(plate_id)
-    if not internal_path and plate_id == 1:
-        best_preview = assets.get("best")
-        if isinstance(best_preview, str):
-            internal_path = best_preview
-    if not internal_path:
+    result = _get_cached_preview(upload_id, str(plate_id), source_3mf)
+    if not result:
         raise HTTPException(status_code=404, detail="Plate preview not available")
 
-    try:
-        with zipfile.ZipFile(source_3mf, "r") as zf:
-            image_bytes = zf.read(internal_path)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to read plate preview: {e}")
-
-    return Response(content=image_bytes, media_type=_guess_image_media_type(internal_path))
+    return Response(content=result[0], media_type=result[1])
 
 
 @router.get("/uploads/{upload_id}/preview")
@@ -3071,14 +3241,9 @@ async def get_upload_preview(upload_id: int):
     pool = get_pg_pool()
     async with pool.acquire() as conn:
         upload = await conn.fetchrow(
-            """
-            SELECT id, file_path
-            FROM uploads
-            WHERE id = $1
-            """,
+            "SELECT id, file_path FROM uploads WHERE id = $1",
             upload_id,
         )
-
         if not upload:
             raise HTTPException(status_code=404, detail="Upload not found")
 
@@ -3086,18 +3251,11 @@ async def get_upload_preview(upload_id: int):
     if not source_3mf.exists():
         raise HTTPException(status_code=404, detail="Source 3MF file not found")
 
-    assets = _index_preview_assets(source_3mf)
-    best_preview = assets.get("best")
-    if not isinstance(best_preview, str) or not best_preview:
+    result = _get_cached_preview(upload_id, "best", source_3mf)
+    if not result:
         raise HTTPException(status_code=404, detail="Upload preview not available")
 
-    try:
-        with zipfile.ZipFile(source_3mf, "r") as zf:
-            image_bytes = zf.read(best_preview)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to read upload preview: {e}")
-
-    return Response(content=image_bytes, media_type=_guess_image_media_type(best_preview))
+    return Response(content=result[0], media_type=result[1])
 
 
 @router.get("/jobs/{job_id}")
@@ -3341,7 +3499,9 @@ async def get_gcode_metadata(job_id: str):
         job = await conn.fetchrow(
             """
             SELECT gcode_path, status, layer_count,
-                   estimated_time_seconds, filament_used_mm
+                   estimated_time_seconds, filament_used_mm,
+                   gcode_bounds_min_x, gcode_bounds_min_y, gcode_bounds_min_z,
+                   gcode_bounds_max_x, gcode_bounds_max_y, gcode_bounds_max_z
             FROM slicing_jobs
             WHERE job_id = $1
             """,
@@ -3358,8 +3518,18 @@ async def get_gcode_metadata(job_id: str):
         if not gcode_path.exists():
             raise HTTPException(status_code=404, detail="G-code file not found")
 
-    # Parse G-code for bounds
-    bounds = _parse_gcode_bounds(gcode_path)
+    # Use cached bounds from DB if available, else fall back to file scan (legacy jobs)
+    if job["gcode_bounds_max_x"] is not None:
+        bounds = {
+            "min_x": job["gcode_bounds_min_x"] or 0.0,
+            "min_y": job["gcode_bounds_min_y"] or 0.0,
+            "min_z": job["gcode_bounds_min_z"] or 0.0,
+            "max_x": job["gcode_bounds_max_x"] or 0.0,
+            "max_y": job["gcode_bounds_max_y"] or 0.0,
+            "max_z": job["gcode_bounds_max_z"] or 0.0,
+        }
+    else:
+        bounds = _parse_gcode_bounds(gcode_path)
 
     return {
         "layer_count": job["layer_count"] or 0,
@@ -3404,7 +3574,6 @@ def _parse_gcode_bounds(gcode_path: Path) -> Dict[str, float]:
     }
 
     current_x, current_y, current_z = 0.0, 0.0, 0.0
-    pattern = re.compile(r'([XYZ])([\d.-]+)')
 
     try:
         with open(gcode_path, 'r') as f:
@@ -3416,7 +3585,7 @@ def _parse_gcode_bounds(gcode_path: Path) -> Dict[str, float]:
                     continue
 
                 # Parse coordinates
-                parts = dict(pattern.findall(line))
+                parts = dict(_RE_GCODE_COORD.findall(line))
 
                 if 'X' in parts:
                     current_x = float(parts['X'])
@@ -3464,9 +3633,9 @@ def _parse_gcode_layers(gcode_path: Path, start: int, count: int) -> List[Dict]:
     relative_extrusion = False
     layer_moves = []
 
-    pattern = re.compile(r'([GXYZEF])([\d.-]+)')
-    layer_comment_re = re.compile(r'^;\s*(LAYER_CHANGE|CHANGE_LAYER)\b', re.IGNORECASE)
-    layer_number_re = re.compile(r'^;\s*LAYER\s*:\s*(\d+)\b', re.IGNORECASE)
+    pattern = _RE_GCODE_FIELDS
+    layer_comment_re = _RE_LAYER_CHANGE
+    layer_number_re = _RE_LAYER_NUMBER
 
     def flush_layer() -> bool:
         """Flush current buffered moves if layer is in range.

--- a/apps/api/app/schema.sql
+++ b/apps/api/app/schema.sql
@@ -101,6 +101,16 @@ ALTER TABLE slicing_jobs ADD COLUMN IF NOT EXISTS filament_colors TEXT;
 -- Migration: Add filament_used_g column to existing databases
 ALTER TABLE slicing_jobs ADD COLUMN IF NOT EXISTS filament_used_g TEXT;
 
+-- Migration: Cache G-code bounds in DB (avoids full file rescan on every viewer open)
+ALTER TABLE slicing_jobs ADD COLUMN IF NOT EXISTS gcode_bounds_min_x REAL;
+ALTER TABLE slicing_jobs ADD COLUMN IF NOT EXISTS gcode_bounds_min_y REAL;
+ALTER TABLE slicing_jobs ADD COLUMN IF NOT EXISTS gcode_bounds_min_z REAL;
+ALTER TABLE slicing_jobs ADD COLUMN IF NOT EXISTS gcode_bounds_max_x REAL;
+ALTER TABLE slicing_jobs ADD COLUMN IF NOT EXISTS gcode_bounds_max_y REAL;
+ALTER TABLE slicing_jobs ADD COLUMN IF NOT EXISTS gcode_bounds_max_z REAL;
+
+CREATE INDEX IF NOT EXISTS idx_slicing_jobs_status ON slicing_jobs(status);
+
 -- Persistent extruder preset mapping (E1-E4)
 CREATE TABLE IF NOT EXISTS extruder_presets (
     slot INTEGER PRIMARY KEY,

--- a/apps/api/app/slicer.py
+++ b/apps/api/app/slicer.py
@@ -344,10 +344,19 @@ class OrcaSlicer:
             "filament_used_mm": metadata.filament_used_mm,
             "filament_used_g": metadata.filament_used_g,
             "layer_count": metadata.layer_count,
+            "min_x": metadata.min_x,
+            "min_y": metadata.min_y,
+            "min_z": metadata.min_z,
+            "max_x": metadata.max_x,
+            "max_y": metadata.max_y,
+            "max_z": metadata.max_z,
             "bounds": {
+                "min_x": metadata.min_x,
+                "min_y": metadata.min_y,
+                "min_z": metadata.min_z,
                 "max_x": metadata.max_x,
                 "max_y": metadata.max_y,
-                "max_z": metadata.max_z
+                "max_z": metadata.max_z,
             }
         }
 

--- a/apps/api/app/upload_processor.py
+++ b/apps/api/app/upload_processor.py
@@ -11,10 +11,10 @@ import logging
 from pathlib import Path
 
 from db import get_pg_pool
-from parser_3mf import parse_3mf, detect_colors_from_3mf, detect_colors_per_plate, detect_print_settings
+from parser_3mf import extract_upload_metadata
 from plate_validator import PlateValidator, PlateValidationError
 from config import get_printer_profile
-from multi_plate_parser import parse_multi_plate_3mf
+from multi_plate_parser import parse_multi_plate_3mf, calculate_all_bounds
 
 logger = logging.getLogger(__name__)
 
@@ -25,13 +25,18 @@ def _process_3mf_sync(file_path: Path, filename: str):
     Runs in a worker thread via asyncio.to_thread() to avoid blocking the
     event loop for large/complex files.
 
+    Optimised to minimise ZIP opens:
+      1. parse_multi_plate_3mf  → ZIP open #1 (plates + structure)
+      2. calculate_all_bounds   → ZIP open #2 (single-pass vertex scan)
+      3. extract_upload_metadata → ZIP open #3 (colors, settings, previews)
+      4. validate_precomputed_bounds → pure math, no I/O
+
     Returns a dict with all parsed data needed for DB insert + response.
     Raises ValueError (400) or RuntimeError (500).
     """
-    # Parse .3mf and extract object/plate metadata
+    # ── Step 1: Parse plates (ZIP open #1) ────────────────────────
     try:
         plates, is_multi_plate = parse_multi_plate_3mf(file_path)
-        objects = parse_3mf(file_path)
     except ValueError as e:
         file_path.unlink(missing_ok=True)
         raise ValueError(str(e))
@@ -39,48 +44,82 @@ def _process_3mf_sync(file_path: Path, filename: str):
         file_path.unlink(missing_ok=True)
         raise RuntimeError(f"Failed to parse .3mf: {str(e)}")
 
-    if not objects:
+    # ── Step 2: Single-pass bounds for ALL plates (ZIP open #2) ───
+    try:
+        all_bounds = calculate_all_bounds(file_path, plates)
+    except ValueError as e:
+        file_path.unlink(missing_ok=True)
+        raise ValueError(str(e))
+    except Exception as e:
+        file_path.unlink(missing_ok=True)
+        raise RuntimeError(f"Failed to calculate bounds: {str(e)}")
+
+    objects_count = all_bounds["objects_count"]
+    if objects_count == 0:
         file_path.unlink(missing_ok=True)
         raise ValueError("No valid objects found in .3mf file")
 
-    objects_count = len(objects)
+    # ── Step 3: Single-pass metadata extraction (ZIP open #3) ─────
+    metadata = extract_upload_metadata(file_path)
+    detected_colors = metadata["detected_colors"]
+    file_print_settings = metadata["print_settings"]
+    colors_per_plate = metadata["colors_per_plate"]
+    preview_assets = metadata["preview_assets"]
+    has_bambu_z_offset = metadata["has_bambu_z_offset"]
 
-    # Validate plate bounds
+    # ── Step 4: Validate bounds (no I/O) ──────────────────────────
     try:
         printer_profile = get_printer_profile("snapmaker_u1")
         validator = PlateValidator(printer_profile)
-        validation = validator.validate_3mf_bounds(file_path, plates=plates)
 
+        # Validate combined bounds
+        combined_bounds = all_bounds["combined"]
+        validation = validator.validate_precomputed_bounds(
+            combined_bounds, is_multi_plate=is_multi_plate,
+            is_bambu_z_offset=has_bambu_z_offset,
+        )
+        validation["is_multi_plate"] = is_multi_plate
+        validation["plates"] = [p.to_dict() for p in plates] if is_multi_plate else []
+
+        # Validate per-plate bounds
         plate_validations = []
-        if validation.get('is_multi_plate'):
-            for plate in validation.get('plates', []):
-                try:
-                    plate_id = plate['plate_id']
-                    plate_validation = validator.validate_3mf_bounds(file_path, plate_id, plates=plates)
+        if is_multi_plate:
+            for plate in plates:
+                pid = plate.plate_id
+                plate_bounds = all_bounds["per_plate"].get(pid)
+                if plate_bounds:
+                    pv = validator.validate_precomputed_bounds(
+                        plate_bounds, is_bambu_z_offset=has_bambu_z_offset,
+                    )
                     plate_validations.append({
-                        "plate_id": plate['plate_id'],
-                        "bounds": plate_validation['bounds'],
-                        "warnings": plate_validation['warnings'],
-                        "fits": plate_validation['fits']
+                        "plate_id": pid,
+                        "bounds": pv["bounds"],
+                        "warnings": pv["warnings"],
+                        "fits": pv["fits"],
                     })
-                except Exception as e:
-                    logger.error(f"Failed to validate plate {plate.get('plate_id')}: {str(e)}")
+                else:
                     plate_validations.append({
-                        "plate_id": plate.get('plate_id'),
-                        "error": str(e),
-                        "fits": False
+                        "plate_id": pid,
+                        "error": "No geometry found",
+                        "fits": False,
                     })
 
-            any_plate_fits = any(p.get('fits', False) for p in plate_validations)
+            # If any individual plate fits, suppress combined-level size warnings
+            any_plate_fits = any(p.get("fits", False) for p in plate_validations)
             if any_plate_fits:
-                validation['warnings'] = [
-                    w for w in validation.get('warnings', [])
+                validation["warnings"] = [
+                    w for w in validation.get("warnings", [])
                     if "exceeds build volume" not in w.lower()
                     and "multi-plate file with" not in w.lower()
                 ]
-                validation['fits'] = True
-        else:
-            plate_validations = []
+                validation["fits"] = True
+
+            # Add multi-plate advisory
+            validation["warnings"].append(
+                f"Multi-plate file with {len(plates)} plates. "
+                "Individual plates may fit even if combined bounds exceed build volume."
+            )
+
     except PlateValidationError as e:
         file_path.unlink(missing_ok=True)
         raise ValueError(f"Plate validation failed: {str(e)}")
@@ -88,34 +127,12 @@ def _process_3mf_sync(file_path: Path, filename: str):
         file_path.unlink(missing_ok=True)
         raise RuntimeError(f"Failed to validate plate: {str(e)}")
 
-    # Detect colors and print settings
-    detected_colors = []
-    try:
-        detected_colors = detect_colors_from_3mf(file_path)
-    except Exception as e:
-        logger.warning(f"Failed to detect colors: {e}")
-
-    file_print_settings = {}
-    try:
-        file_print_settings = detect_print_settings(file_path)
-    except Exception as e:
-        logger.warning(f"Failed to detect print settings: {e}")
-
-    # Build plate_metadata cache for multi-plate files
-    is_multi_plate = validation.get('is_multi_plate', False)
+    # ── Build plate_metadata cache for multi-plate files ──────────
     plate_metadata_json = None
     if is_multi_plate and plates:
-        from routes_slice import _index_preview_assets
         try:
-            preview_assets = _index_preview_assets(file_path)
             preview_map = preview_assets.get("by_plate", {})
             has_generic_preview = isinstance(preview_assets.get("best"), str)
-
-            colors_per_plate = {}
-            try:
-                colors_per_plate = detect_colors_per_plate(file_path)
-            except Exception:
-                pass
 
             plate_info_cache = []
             for plate in plates:

--- a/apps/web/app.js
+++ b/apps/web/app.js
@@ -229,14 +229,19 @@ function app() {
 
             // Load initial data — printer check runs in parallel so it
             // doesn't block file lists when Moonraker is slow/unreachable.
-            this.fetchVersion(); // non-blocking
-            this.loadOrcaDefaults(); // non-blocking
-            this.loadPrinterSettings(); // non-blocking, pre-load for settings modal
-            this.checkPrinterStatus(false); // non-blocking — updates header indicator async
-            await this.loadFilaments();
-            await this.loadExtruderPresets();
-            await this.loadRecentUploads();
-            await this.loadJobs();
+            // Fire-and-forget calls (no await needed)
+            this.fetchVersion();
+            this.loadOrcaDefaults();
+            this.loadPrinterSettings();
+            this.checkPrinterStatus(false);
+
+            // Load essential data in parallel (these are independent)
+            await Promise.all([
+                this.loadFilaments(),
+                this.loadExtruderPresets(),
+                this.loadRecentUploads(),
+                this.loadJobs(),
+            ]);
 
             // Set up periodic printer status check
             setInterval(() => this.checkPrinterStatus(this.webcamsExpanded), 30000); // Every 30 seconds


### PR DESCRIPTION
## Summary
- **Upload processing**: Reduced from ~16 ZIP opens to 3 via single-pass metadata extraction (`extract_upload_metadata`, `calculate_all_bounds`, `validate_precomputed_bounds`)
- **G-code parser**: Rewritten to single-pass (was 3 file reads), bounds cached in DB at slice completion — metadata endpoint reads from DB instead of re-scanning file
- **Profile embedder**: Consolidated 5-7 detection functions into single `_analyze_source_3mf()` (1 ZIP open)
- **Preview images**: Cached in-memory after first extraction (was 2 ZIP opens per request)
- **Bambu plate metadata**: Batched into single ZIP open for layout/geometry endpoints
- **Frontend init**: Parallelized 4 independent API calls with `Promise.all()`
- **AGENTS.md**: Added convention to always investigate test failures as regressions

## Test plan
- [x] All 114 fast tests passing (0 failures)
- [x] Copies scale tests specifically verified (were failing before bounds fix in slicer.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)