### PR TITLE
Fix multicolour extruder assignment for non-default positions

### DIFF
--- a/apps/api/app/routes_slice.py
+++ b/apps/api/app/routes_slice.py
@@ -1541,12 +1541,6 @@ async def slice_upload(upload_id: int, request: SliceRequest):
             material_types.append(str(f.get("material", "PLA") or "PLA"))
             profile_names.append(str(f.get("name", "Snapmaker PLA") or "Snapmaker PLA"))
         
-        # Override colors if user specified custom colors per extruder
-        if request.filament_colors:
-            for idx, color in enumerate(request.filament_colors):
-                if idx < len(extruder_colors):
-                    extruder_colors[idx] = color
-
         # Place filament settings into correct positional slots.
         # When extruder_assignments maps filaments to non-default positions
         # (e.g. filament_ids=[A,B] + assignments=[2,3]), scatter each
@@ -1593,6 +1587,14 @@ async def slice_upload(upload_id: int, request: SliceRequest):
                 material_types.append(material_types[-1] if material_types else "PLA")
             while len(profile_names) < 4:
                 profile_names.append(profile_names[-1] if profile_names else "Snapmaker PLA")
+
+        # Override colors if user specified custom colors per extruder.
+        # Applied AFTER scatter so request.filament_colors (a positional 4-slot
+        # array from the UI) patches the full positional extruder_colors array.
+        if request.filament_colors:
+            for idx, color in enumerate(request.filament_colors):
+                if idx < len(extruder_colors):
+                    extruder_colors[idx] = color
 
         # Create extruder count setting (how many filaments we're using)
         remap_slots = max(extruder_remap.values()) if extruder_remap else 0
@@ -1995,8 +1997,14 @@ async def slice_upload(upload_id: int, request: SliceRequest):
         gcode_size_mb = gcode_size / 1024 / 1024
         job_logger.info(f"G-code saved: {final_gcode_path} ({gcode_size_mb:.2f} MB)")
 
-        # Update database with results
-        filament_colors_json = json.dumps(extruder_colors[:len(filaments)])
+        # Update database with results — extract colors from active positions
+        # After scatter, extruder_colors is positional (e.g. assignments [2,3]
+        # puts colors at indices 2,3). Use assigned positions, not [:len].
+        if request.extruder_assignments:
+            active_colors = [extruder_colors[pos] for pos in request.extruder_assignments if pos < len(extruder_colors)]
+        else:
+            active_colors = extruder_colors[:len(filaments)]
+        filament_colors_json = json.dumps(active_colors)
         filament_used_g_json = json.dumps(metadata.get('filament_used_g', []))
         async with pool.acquire() as conn:
             # Only mark completed if the job hasn't been cancelled in the meantime.
@@ -2059,7 +2067,6 @@ async def slice_upload(upload_id: int, request: SliceRequest):
             display_colors = detected_colors
         else:
             display_colors = json.loads(filament_colors_json)
-
         _clear_progress(job_id)
         return {
             "job_id": job_id,
@@ -2360,12 +2367,6 @@ async def slice_plate(upload_id: int, request: SlicePlateRequest):
             material_types.append(str(f.get("material", "PLA") or "PLA"))
             profile_names.append(str(f.get("name", "Snapmaker PLA") or "Snapmaker PLA"))
         
-        # Override colors if user specified custom colors per extruder
-        if request.filament_colors:
-            for idx, color in enumerate(request.filament_colors):
-                if idx < len(extruder_colors):
-                    extruder_colors[idx] = color
-
         # Place filament settings into correct positional slots.
         # When extruder_assignments maps filaments to non-default positions
         # (e.g. filament_ids=[A,B] + assignments=[2,3]), scatter each
@@ -2412,6 +2413,14 @@ async def slice_plate(upload_id: int, request: SlicePlateRequest):
                 material_types.append(material_types[-1] if material_types else "PLA")
             while len(profile_names) < 4:
                 profile_names.append(profile_names[-1] if profile_names else "Snapmaker PLA")
+
+        # Override colors if user specified custom colors per extruder.
+        # Applied AFTER scatter so request.filament_colors (a positional 4-slot
+        # array from the UI) patches the full positional extruder_colors array.
+        if request.filament_colors:
+            for idx, color in enumerate(request.filament_colors):
+                if idx < len(extruder_colors):
+                    extruder_colors[idx] = color
 
         remap_slots = max(extruder_remap.values()) if extruder_remap else 0
         extruder_count = max(len(filaments), remap_slots)
@@ -2781,8 +2790,12 @@ async def slice_plate(upload_id: int, request: SlicePlateRequest):
         gcode_size_mb = gcode_size / 1024 / 1024
         job_logger.info(f"G-code saved: {final_gcode_path} ({gcode_size_mb:.2f} MB)")
 
-        # Update database with results
-        filament_colors_json = json.dumps(extruder_colors[:len(filaments)])
+        # Update database with results — extract colors from active positions
+        if request.extruder_assignments:
+            active_colors = [extruder_colors[pos] for pos in request.extruder_assignments if pos < len(extruder_colors)]
+        else:
+            active_colors = extruder_colors[:len(filaments)]
+        filament_colors_json = json.dumps(active_colors)
         filament_used_g_json = json.dumps(metadata.get('filament_used_g', []))
         async with pool.acquire() as conn:
             result_tag = await conn.execute(

--- a/apps/api/app/routes_slice.py
+++ b/apps/api/app/routes_slice.py
@@ -1546,28 +1546,53 @@ async def slice_upload(upload_id: int, request: SliceRequest):
             for idx, color in enumerate(request.filament_colors):
                 if idx < len(extruder_colors):
                     extruder_colors[idx] = color
-        
-        # Pad to 4 extruders (unused nozzles get 0°C to avoid heating)
-        while len(nozzle_temps) < 4:
-            nozzle_temps.append("0")
-        while len(bed_temps) < 4:
-            bed_temps.append(bed_temps[-1] if bed_temps else "60")
-        while len(extruder_colors) < 4:
-            extruder_colors.append("#FFFFFF")
-        while len(material_types) < 4:
-            material_types.append(material_types[-1] if material_types else "PLA")
-        while len(profile_names) < 4:
-            profile_names.append(profile_names[-1] if profile_names else "Snapmaker PLA")
 
-        # Zero out nozzle temps for extruder positions not actively used.
-        # Frontend fills gap positions with a default filament (which has a real temp),
-        # so we must explicitly disable heating for unused physical extruders.
+        # Place filament settings into correct positional slots.
+        # When extruder_assignments maps filaments to non-default positions
+        # (e.g. filament_ids=[A,B] + assignments=[2,3]), scatter each
+        # filament's properties into the assigned slot so temps/colors
+        # align with physical extruder positions.
         if request.extruder_assignments:
-            active_positions = set(request.extruder_assignments)
-            for i in range(len(nozzle_temps)):
-                if i not in active_positions:
-                    nozzle_temps[i] = "0"
-            job_logger.info(f"Active extruder positions: {sorted(active_positions)}, zeroed inactive nozzle temps")
+            pos_nozzle = ["0"] * 4
+            default_bed = bed_temps[-1] if bed_temps else "60"
+            pos_bed = [default_bed] * 4
+            pos_colors = ["#FFFFFF"] * 4
+            default_mat = material_types[-1] if material_types else "PLA"
+            pos_materials = [default_mat] * 4
+            default_prof = profile_names[-1] if profile_names else "Snapmaker PLA"
+            pos_profiles = [default_prof] * 4
+
+            for i, pos in enumerate(request.extruder_assignments):
+                if pos < 4:
+                    if i < len(nozzle_temps):
+                        pos_nozzle[pos] = nozzle_temps[i]
+                    if i < len(bed_temps):
+                        pos_bed[pos] = bed_temps[i]
+                    if i < len(extruder_colors):
+                        pos_colors[pos] = extruder_colors[i]
+                    if i < len(material_types):
+                        pos_materials[pos] = material_types[i]
+                    if i < len(profile_names):
+                        pos_profiles[pos] = profile_names[i]
+
+            nozzle_temps = pos_nozzle
+            bed_temps = pos_bed
+            extruder_colors = pos_colors
+            material_types = pos_materials
+            profile_names = pos_profiles
+            job_logger.info(f"Positioned filament settings to extruder slots: {sorted(set(request.extruder_assignments))}, nozzle_temps={nozzle_temps}")
+        else:
+            # No assignments — pad sequentially (unused nozzles get 0°C)
+            while len(nozzle_temps) < 4:
+                nozzle_temps.append("0")
+            while len(bed_temps) < 4:
+                bed_temps.append(bed_temps[-1] if bed_temps else "60")
+            while len(extruder_colors) < 4:
+                extruder_colors.append("#FFFFFF")
+            while len(material_types) < 4:
+                material_types.append(material_types[-1] if material_types else "PLA")
+            while len(profile_names) < 4:
+                profile_names.append(profile_names[-1] if profile_names else "Snapmaker PLA")
 
         # Create extruder count setting (how many filaments we're using)
         remap_slots = max(extruder_remap.values()) if extruder_remap else 0
@@ -2340,28 +2365,53 @@ async def slice_plate(upload_id: int, request: SlicePlateRequest):
             for idx, color in enumerate(request.filament_colors):
                 if idx < len(extruder_colors):
                     extruder_colors[idx] = color
-        
-        # Pad to 4 extruders (unused nozzles get 0°C to avoid heating)
-        while len(nozzle_temps) < 4:
-            nozzle_temps.append("0")
-        while len(bed_temps) < 4:
-            bed_temps.append(bed_temps[-1] if bed_temps else "60")
-        while len(extruder_colors) < 4:
-            extruder_colors.append("#FFFFFF")
-        while len(material_types) < 4:
-            material_types.append(material_types[-1] if material_types else "PLA")
-        while len(profile_names) < 4:
-            profile_names.append(profile_names[-1] if profile_names else "Snapmaker PLA")
 
-        # Zero out nozzle temps for extruder positions not actively used.
-        # Frontend fills gap positions with a default filament (which has a real temp),
-        # so we must explicitly disable heating for unused physical extruders.
+        # Place filament settings into correct positional slots.
+        # When extruder_assignments maps filaments to non-default positions
+        # (e.g. filament_ids=[A,B] + assignments=[2,3]), scatter each
+        # filament's properties into the assigned slot so temps/colors
+        # align with physical extruder positions.
         if request.extruder_assignments:
-            active_positions = set(request.extruder_assignments)
-            for i in range(len(nozzle_temps)):
-                if i not in active_positions:
-                    nozzle_temps[i] = "0"
-            job_logger.info(f"Active extruder positions: {sorted(active_positions)}, zeroed inactive nozzle temps")
+            pos_nozzle = ["0"] * 4
+            default_bed = bed_temps[-1] if bed_temps else "60"
+            pos_bed = [default_bed] * 4
+            pos_colors = ["#FFFFFF"] * 4
+            default_mat = material_types[-1] if material_types else "PLA"
+            pos_materials = [default_mat] * 4
+            default_prof = profile_names[-1] if profile_names else "Snapmaker PLA"
+            pos_profiles = [default_prof] * 4
+
+            for i, pos in enumerate(request.extruder_assignments):
+                if pos < 4:
+                    if i < len(nozzle_temps):
+                        pos_nozzle[pos] = nozzle_temps[i]
+                    if i < len(bed_temps):
+                        pos_bed[pos] = bed_temps[i]
+                    if i < len(extruder_colors):
+                        pos_colors[pos] = extruder_colors[i]
+                    if i < len(material_types):
+                        pos_materials[pos] = material_types[i]
+                    if i < len(profile_names):
+                        pos_profiles[pos] = profile_names[i]
+
+            nozzle_temps = pos_nozzle
+            bed_temps = pos_bed
+            extruder_colors = pos_colors
+            material_types = pos_materials
+            profile_names = pos_profiles
+            job_logger.info(f"Positioned filament settings to extruder slots: {sorted(set(request.extruder_assignments))}, nozzle_temps={nozzle_temps}")
+        else:
+            # No assignments — pad sequentially (unused nozzles get 0°C)
+            while len(nozzle_temps) < 4:
+                nozzle_temps.append("0")
+            while len(bed_temps) < 4:
+                bed_temps.append(bed_temps[-1] if bed_temps else "60")
+            while len(extruder_colors) < 4:
+                extruder_colors.append("#FFFFFF")
+            while len(material_types) < 4:
+                material_types.append(material_types[-1] if material_types else "PLA")
+            while len(profile_names) < 4:
+                profile_names.append(profile_names[-1] if profile_names else "Snapmaker PLA")
 
         remap_slots = max(extruder_remap.values()) if extruder_remap else 0
         extruder_count = max(len(filaments), remap_slots)

--- a/apps/api/app/routes_slice.py
+++ b/apps/api/app/routes_slice.py
@@ -1547,9 +1547,9 @@ async def slice_upload(upload_id: int, request: SliceRequest):
                 if idx < len(extruder_colors):
                     extruder_colors[idx] = color
         
-        # Pad to 4 extruders (use last values for unused extruders)
+        # Pad to 4 extruders (unused nozzles get 0°C to avoid heating)
         while len(nozzle_temps) < 4:
-            nozzle_temps.append(nozzle_temps[-1] if nozzle_temps else "200")
+            nozzle_temps.append("0")
         while len(bed_temps) < 4:
             bed_temps.append(bed_temps[-1] if bed_temps else "60")
         while len(extruder_colors) < 4:
@@ -1558,11 +1558,21 @@ async def slice_upload(upload_id: int, request: SliceRequest):
             material_types.append(material_types[-1] if material_types else "PLA")
         while len(profile_names) < 4:
             profile_names.append(profile_names[-1] if profile_names else "Snapmaker PLA")
-        
+
+        # Zero out nozzle temps for extruder positions not actively used.
+        # Frontend fills gap positions with a default filament (which has a real temp),
+        # so we must explicitly disable heating for unused physical extruders.
+        if request.extruder_assignments:
+            active_positions = set(request.extruder_assignments)
+            for i in range(len(nozzle_temps)):
+                if i not in active_positions:
+                    nozzle_temps[i] = "0"
+            job_logger.info(f"Active extruder positions: {sorted(active_positions)}, zeroed inactive nozzle temps")
+
         # Create extruder count setting (how many filaments we're using)
         remap_slots = max(extruder_remap.values()) if extruder_remap else 0
         extruder_count = max(len(filaments), remap_slots)
-        
+
         # Get the first filament's bed type for the plate
         first_filament = filaments[0]
         bed_type = request.bed_type if request.bed_type is not None else first_filament.get("bed_type", "PEI")
@@ -1664,7 +1674,7 @@ async def slice_upload(upload_id: int, request: SliceRequest):
                 filament_settings=filament_settings,
                 overrides=overrides,
                 requested_filament_count=extruder_count,
-                extruder_remap=extruder_remap if has_overflow_extruders else None,
+                extruder_remap=extruder_remap or None,
                 preserve_geometry=True,
                 precomputed_is_bambu=model.is_bambu,
                 precomputed_has_multi_assignments=model.has_multi_extruder_assignments,
@@ -1815,7 +1825,7 @@ async def slice_upload(upload_id: int, request: SliceRequest):
                 filament_settings=filament_settings,
                 overrides=retry_overrides,
                 requested_filament_count=extruder_count,
-                extruder_remap=extruder_remap if has_overflow_extruders else None,
+                extruder_remap=extruder_remap or None,
                 preserve_geometry=True,
                 precomputed_is_bambu=model.is_bambu,
                 precomputed_has_multi_assignments=model.has_multi_extruder_assignments,
@@ -1895,15 +1905,13 @@ async def slice_upload(upload_id: int, request: SliceRequest):
         gcode_workspace_path = gcode_files[0]
         job_logger.info(f"Found G-code file: {gcode_workspace_path.name}")
 
-        if len(filaments) > 1 and extruder_remap:
-            if has_overflow_extruders:
-                # Pre-slice remap already collapsed >4 to 1-4 in the 3MF.
-                # Post-slice remap only needs to fix compaction within 1-4.
-                effective_extruders = sorted(set(extruder_remap.values()))
-                target_tools = [ext - 1 for ext in effective_extruders]
-            else:
-                ordered_sources = sorted(extruder_remap.keys())
-                target_tools = [extruder_remap[src] - 1 for src in ordered_sources]
+        if len(filaments) > 1 and extruder_remap and has_overflow_extruders:
+            # Pre-slice remap already collapsed >4 to 1-4 in the 3MF.
+            # Post-slice remap only needs to fix compaction within 1-4.
+            # Non-overflow remaps (e.g. E1,E2→E3,E4) are handled pre-slice
+            # so OrcaSlicer generates correct tool numbers and is_extruder_used[].
+            effective_extruders = sorted(set(extruder_remap.values()))
+            target_tools = [ext - 1 for ext in effective_extruders]
             remap_result = slicer.remap_compacted_tools(gcode_workspace_path, target_tools)
             if remap_result.get("applied"):
                 job_logger.info(f"Remapped compacted tools: {remap_result.get('map')}")
@@ -2333,9 +2341,9 @@ async def slice_plate(upload_id: int, request: SlicePlateRequest):
                 if idx < len(extruder_colors):
                     extruder_colors[idx] = color
         
-        # Pad to 4 extruders
+        # Pad to 4 extruders (unused nozzles get 0°C to avoid heating)
         while len(nozzle_temps) < 4:
-            nozzle_temps.append(nozzle_temps[-1] if nozzle_temps else "200")
+            nozzle_temps.append("0")
         while len(bed_temps) < 4:
             bed_temps.append(bed_temps[-1] if bed_temps else "60")
         while len(extruder_colors) < 4:
@@ -2344,7 +2352,17 @@ async def slice_plate(upload_id: int, request: SlicePlateRequest):
             material_types.append(material_types[-1] if material_types else "PLA")
         while len(profile_names) < 4:
             profile_names.append(profile_names[-1] if profile_names else "Snapmaker PLA")
-        
+
+        # Zero out nozzle temps for extruder positions not actively used.
+        # Frontend fills gap positions with a default filament (which has a real temp),
+        # so we must explicitly disable heating for unused physical extruders.
+        if request.extruder_assignments:
+            active_positions = set(request.extruder_assignments)
+            for i in range(len(nozzle_temps)):
+                if i not in active_positions:
+                    nozzle_temps[i] = "0"
+            job_logger.info(f"Active extruder positions: {sorted(active_positions)}, zeroed inactive nozzle temps")
+
         remap_slots = max(extruder_remap.values()) if extruder_remap else 0
         extruder_count = max(len(filaments), remap_slots)
         first_filament = filaments[0]
@@ -2455,7 +2473,7 @@ async def slice_plate(upload_id: int, request: SlicePlateRequest):
                 filament_settings=filament_settings,
                 overrides=overrides,
                 requested_filament_count=extruder_count,
-                extruder_remap=extruder_remap if has_overflow_extruders else None,
+                extruder_remap=extruder_remap or None,
                 precomputed_is_bambu=model.is_bambu,
                 precomputed_has_multi_assignments=model.has_multi_extruder_assignments,
                 precomputed_has_layer_changes=model.has_layer_tool_changes,
@@ -2586,7 +2604,7 @@ async def slice_plate(upload_id: int, request: SlicePlateRequest):
                 filament_settings=filament_settings,
                 overrides=retry_overrides,
                 requested_filament_count=extruder_count,
-                extruder_remap=extruder_remap if has_overflow_extruders else None,
+                extruder_remap=extruder_remap or None,
                 preserve_geometry=True,
                 precomputed_is_bambu=model.is_bambu,
                 precomputed_has_multi_assignments=model.has_multi_extruder_assignments,
@@ -2647,15 +2665,13 @@ async def slice_plate(upload_id: int, request: SlicePlateRequest):
         gcode_workspace_path = gcode_files[0]
         job_logger.info(f"Found G-code file: {gcode_workspace_path.name}")
 
-        if len(filaments) > 1 and extruder_remap:
-            if has_overflow_extruders:
-                # Pre-slice remap already collapsed >4 to 1-4 in the 3MF.
-                # Post-slice remap only needs to fix compaction within 1-4.
-                effective_extruders = sorted(set(extruder_remap.values()))
-                target_tools = [ext - 1 for ext in effective_extruders]
-            else:
-                ordered_sources = sorted(extruder_remap.keys())
-                target_tools = [extruder_remap[src] - 1 for src in ordered_sources]
+        if len(filaments) > 1 and extruder_remap and has_overflow_extruders:
+            # Pre-slice remap already collapsed >4 to 1-4 in the 3MF.
+            # Post-slice remap only needs to fix compaction within 1-4.
+            # Non-overflow remaps (e.g. E1,E2→E3,E4) are handled pre-slice
+            # so OrcaSlicer generates correct tool numbers and is_extruder_used[].
+            effective_extruders = sorted(set(extruder_remap.values()))
+            target_tools = [ext - 1 for ext in effective_extruders]
             remap_result = slicer.remap_compacted_tools(gcode_workspace_path, target_tools)
             if remap_result.get("applied"):
                 job_logger.info(f"Remapped compacted tools: {remap_result.get('map')}")

--- a/apps/web/app.js
+++ b/apps/web/app.js
@@ -2963,9 +2963,8 @@ function app() {
             if (mappedFromPresets && mappedFromPresets.filamentIds.length === allColors.length) {
                 this.selectedFilaments = mappedFromPresets.filamentIds;
                 this.sliceSettings.extruder_assignments = mappedFromPresets.assignments;
-                // Use the preset/extruder colors (what's physically loaded), not the
-                // detected file colors (what the designer intended). syncFilamentColors
-                // will further refine from filament profile color_hex if available.
+                // Use preset/physical colors for filament_colors — these represent
+                // what's actually loaded in the extruder and drive the G-code viewer.
                 this.sliceSettings.filament_colors = mappedFromPresets.mappedColors;
                 this.syncFilamentColors();
                 return;
@@ -3027,6 +3026,7 @@ function app() {
                 // If the filament profile has a real (non-default) color, use it.
                 if (profileColor && profileColor.toUpperCase() !== '#FFFFFF') return profileColor;
                 // Use the assigned extruder slot (not position index) for preset lookup.
+                // Preset colors reflect what's physically loaded in the extruder.
                 const presetIdx = assignments[idx] ?? idx;
                 const presetColor = this.extruderPresets?.[presetIdx]?.color_hex;
                 if (presetColor && presetColor.toUpperCase() !== '#FFFFFF') return presetColor;

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -552,7 +552,6 @@
                                                         <span class="font-medium" x-text="`E${(sliceSettings.extruder_assignments?.[idx] ?? idx) + 1}`"></span>
                                                         <div class="w-3 h-3 rounded-full border border-gray-300 flex-shrink-0"
                                                              :style="`background-color: ${extruderPresets[(sliceSettings.extruder_assignments?.[idx] ?? idx)]?.color_hex || '#FFFFFF'}`"></div>
-                                                        <span class="text-gray-500" x-text="`(${colorName(extruderPresets[(sliceSettings.extruder_assignments?.[idx] ?? idx)]?.color_hex || '#FFFFFF')})`"></span>
                                                         <span class="text-gray-400">&#8226;</span>
                                                         <span class="text-gray-600" x-text="getFilamentById(selectedFilaments?.[idx])?.name || 'Unassigned'"></span>
                                                     </div>
@@ -595,14 +594,27 @@
                                                                            x-model="sliceSettings.filament_colors[idx]"
                                                                            class="w-8 h-8 rounded cursor-pointer border-0"
                                                                            title="Click to change color">
-                                                                    <select :value="sliceSettings.extruder_assignments[idx]"
-                                                                            @change="setExtruderAssignment(idx, Number($event.target.value))"
-                                                                            class="w-36 text-xs border border-gray-300 rounded px-1 py-1 bg-white text-gray-900">
-                                                                        <option value="0" x-text="`E1 (${colorName(extruderPresets[0]?.color_hex || '#FFFFFF')})`"></option>
-                                                                        <option value="1" x-text="`E2 (${colorName(extruderPresets[1]?.color_hex || '#FFFFFF')})`"></option>
-                                                                        <option value="2" x-text="`E3 (${colorName(extruderPresets[2]?.color_hex || '#FFFFFF')})`"></option>
-                                                                        <option value="3" x-text="`E4 (${colorName(extruderPresets[3]?.color_hex || '#FFFFFF')})`"></option>
-                                                                    </select>
+                                                                    <div x-data="{ open: false }" class="relative" @click.outside="open = false">
+                                                                        <button type="button" @click="open = !open"
+                                                                                class="flex items-center gap-1.5 px-2 py-1 text-xs border border-gray-300 rounded bg-white text-gray-900 hover:bg-gray-50 w-24">
+                                                                            <span class="inline-block w-3 h-3 rounded-full border border-gray-300 flex-shrink-0"
+                                                                                  :style="`background-color: ${extruderPresets[sliceSettings.extruder_assignments[idx]]?.color_hex || '#FFFFFF'}`"></span>
+                                                                            <span x-text="`E${(sliceSettings.extruder_assignments[idx] ?? idx) + 1}`"></span>
+                                                                            <svg class="w-3 h-3 ml-auto text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                                                                        </button>
+                                                                        <div x-show="open" x-cloak class="absolute z-50 mt-1 w-28 bg-white border border-gray-200 rounded-lg shadow-lg py-1">
+                                                                            <template x-for="ei in [0,1,2,3]" :key="ei">
+                                                                                <button type="button"
+                                                                                        @click="setExtruderAssignment(idx, ei); open = false"
+                                                                                        class="flex items-center gap-2 w-full px-2 py-1.5 text-xs hover:bg-blue-50 text-left"
+                                                                                        :class="sliceSettings.extruder_assignments[idx] === ei ? 'bg-blue-50 font-semibold' : ''">
+                                                                                    <span class="inline-block w-3 h-3 rounded-full border border-gray-300 flex-shrink-0"
+                                                                                          :style="`background-color: ${extruderPresets[ei]?.color_hex || '#FFFFFF'}`"></span>
+                                                                                    <span x-text="`E${ei + 1}`"></span>
+                                                                                </button>
+                                                                            </template>
+                                                                        </div>
+                                                                    </div>
                                                                     <select x-model.number="selectedFilaments[idx]"
                                                                             @change="syncFilamentColors()"
                                                                             class="flex-1 min-w-0 text-xs border border-gray-300 rounded px-2 py-1 bg-white text-gray-900 truncate">

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Self-hostable Docker-first service for Snapmaker U1 3D printing",
   "scripts": {
     "test": "npx playwright test",
-    "test:fast": "npx playwright test tests/smoke.spec.ts tests/api.spec.ts tests/errors.spec.ts tests/upload.spec.ts tests/stl-upload.spec.ts tests/multicolour.spec.ts tests/multiplate.spec.ts tests/responsive.spec.ts tests/settings.spec.ts tests/slicing.spec.ts tests/backup-restore.spec.ts tests/copies.spec.ts --grep-invert @extended",
+    "test:fast": "npx playwright test tests/smoke.spec.ts tests/api.spec.ts tests/errors.spec.ts tests/upload.spec.ts tests/stl-upload.spec.ts tests/multicolour.spec.ts tests/multicolour-slice.spec.ts tests/multiplate.spec.ts tests/responsive.spec.ts tests/settings.spec.ts tests/slicing.spec.ts tests/backup-restore.spec.ts tests/copies.spec.ts --grep-invert @extended",
     "test:extended": "npx playwright test tests/multicolour.spec.ts tests/multiplate.spec.ts tests/slicing.spec.ts --grep @extended",
     "test:smoke": "npx playwright test tests/smoke.spec.ts tests/api.spec.ts tests/responsive.spec.ts",
     "test:upload": "npx playwright test tests/upload.spec.ts",

--- a/tests/multicolour-slice.spec.ts
+++ b/tests/multicolour-slice.spec.ts
@@ -182,4 +182,56 @@ test.describe('Multicolour Slicing End-to-End (M11)', () => {
     expect(execGcode).not.toMatch(/SM_PRINT_AUTO_FEED\s+EXTRUDER=0/);
     expect(execGcode).not.toMatch(/SM_PRINT_AUTO_FEED\s+EXTRUDER=1/);
   });
+
+  test('sparse filament_ids [A,B] + assignments [2,3] heats E3+E4, not all-zero (API regression)', async ({ request }) => {
+    // Regression: when API consumer sends only 2 filament_ids (not 4 gap-fillers)
+    // with extruder_assignments [2,3], the sequential temp array [T_A, T_B, "0", "0"]
+    // was padded then zeroed — resulting in all nozzles at 0°C because the active
+    // slots (2,3) held padding zeros. Fix: scatter temps into assigned positions.
+    const upload = await apiUpload(request, 'calib-cube-10-dual-colour-merged.3mf');
+    const fil = await getDefaultFilament(request);
+
+    // Only 2 filament_ids — no gap-fillers, direct API usage
+    const res = await request.post(`${API}/uploads/${upload.upload_id}/slice`, {
+      data: {
+        filament_ids: [fil.id, fil.id],
+        extruder_assignments: [2, 3],
+        layer_height: 0.2,
+        infill_density: 15,
+        supports: false,
+      },
+      timeout: 120_000,
+    });
+    expect(res.ok()).toBe(true);
+    const job = await waitForJobComplete(request, await res.json());
+    expect(job.status).toBe('completed');
+
+    // Download G-code and verify nozzle temps are non-zero for active extruders
+    const dlRes = await request.get(`${API}/jobs/${job.job_id}/download`, { timeout: 120_000 });
+    expect(dlRes.ok()).toBe(true);
+    const gcode = await dlRes.text();
+
+    // Verify correct tool numbers (T2/T3, not T0/T1)
+    const toolChangeLines = gcode.split('\n').filter(
+      (line) => /^T[0-3]\s*$/.test(line.trim())
+    );
+    const tools = new Set(toolChangeLines.map((l) => l.trim()));
+    expect(tools.has('T2')).toBe(true);
+    expect(tools.has('T3')).toBe(true);
+    expect(tools.has('T0')).toBe(false);
+    expect(tools.has('T1')).toBe(false);
+
+    // Verify nozzle temperature commands exist with non-zero values.
+    // M104/M109 set nozzle temp; active extruders must have real temps.
+    const tempLines = gcode.split('\n').filter(
+      (line) => /^M10[49]\s/.test(line.trim()) && !/^;/.test(line.trim())
+    );
+    const temps = tempLines.map((l) => {
+      const m = l.match(/S(\d+)/);
+      return m ? parseInt(m[1], 10) : 0;
+    });
+    // At least some temp commands must be non-zero (filament nozzle temp)
+    const nonZeroTemps = temps.filter((t) => t > 0);
+    expect(nonZeroTemps.length).toBeGreaterThan(0);
+  });
 });

--- a/tests/multicolour-slice.spec.ts
+++ b/tests/multicolour-slice.spec.ts
@@ -94,4 +94,92 @@ test.describe('Multicolour Slicing End-to-End (M11)', () => {
     const body = await res.json();
     expect(body.detail).toContain('filament_id');
   });
+
+  test('extruder_assignments [2,3] produces G-code with T2/T3 tools, not T0/T1 (regression)', async ({ request }) => {
+    // Regression: when mapping dual-colour to E3+E4 (assignments [2,3]),
+    // the slicer used to generate T0/T1 and post-process remap. This caused
+    // start G-code to prime E1+E2 instead of E3+E4 because is_extruder_used[]
+    // was wrong. Fix: pre-slice remap in the 3MF so OrcaSlicer knows the
+    // correct extruder positions natively.
+    const upload = await apiUpload(request, 'calib-cube-10-dual-colour-merged.3mf');
+    const fil = await getDefaultFilament(request);
+
+    // Positional array: [E1, E2, E3, E4] — E1/E2 are gap-fillers
+    const res = await request.post(`${API}/uploads/${upload.upload_id}/slice`, {
+      data: {
+        filament_ids: [fil.id, fil.id, fil.id, fil.id],
+        extruder_assignments: [2, 3],
+        layer_height: 0.2,
+        infill_density: 15,
+        supports: false,
+      },
+      timeout: 120_000,
+    });
+    expect(res.ok()).toBe(true);
+    const job = await waitForJobComplete(request, await res.json());
+    expect(job.status).toBe('completed');
+
+    // Download G-code and verify tool usage
+    const dlRes = await request.get(`${API}/jobs/${job.job_id}/download`, { timeout: 120_000 });
+    expect(dlRes.ok()).toBe(true);
+    const gcode = await dlRes.text();
+
+    // Must use T2 and T3 (E3 and E4, 0-indexed)
+    expect(gcode).toContain('T2');
+    expect(gcode).toContain('T3');
+
+    // Must NOT have T0 or T1 tool changes in the print body
+    // (T0/T1 may appear in comments, so check for actual tool change commands)
+    const toolChangeLines = gcode.split('\n').filter(
+      (line) => /^T[0-3]\s*$/.test(line.trim())
+    );
+    const tools = new Set(toolChangeLines.map((l) => l.trim()));
+    expect(tools.has('T0')).toBe(false);
+    expect(tools.has('T1')).toBe(false);
+  });
+
+  test('extruder_assignments [2,3] primes E3+E4, not E1+E2 (regression)', async ({ request }) => {
+    // Regression: start G-code SM_PRINT_AUTO_FEED and SM_PRINT_START_LINE
+    // must target the assigned extruders (E3=INDEX 2, E4=INDEX 3), not the
+    // default E1/E2. This verifies that is_extruder_used[] is correct.
+    const upload = await apiUpload(request, 'calib-cube-10-dual-colour-merged.3mf');
+    const fil = await getDefaultFilament(request);
+
+    const res = await request.post(`${API}/uploads/${upload.upload_id}/slice`, {
+      data: {
+        filament_ids: [fil.id, fil.id, fil.id, fil.id],
+        extruder_assignments: [2, 3],
+        layer_height: 0.2,
+        infill_density: 15,
+        supports: false,
+      },
+      timeout: 120_000,
+    });
+    expect(res.ok()).toBe(true);
+    const job = await waitForJobComplete(request, await res.json());
+    expect(job.status).toBe('completed');
+
+    const dlRes = await request.get(`${API}/jobs/${job.job_id}/download`, { timeout: 120_000 });
+    expect(dlRes.ok()).toBe(true);
+    const gcode = await dlRes.text();
+
+    // Filter to executable lines only (OrcaSlicer appends the raw template
+    // as a "; machine_start_gcode = ..." comment which contains all indices).
+    const execLines = gcode.split('\n').filter((l) => !l.trimStart().startsWith(';'));
+    const execGcode = execLines.join('\n');
+
+    // Start line macros must target E3 and E4 (INDEX=2 and INDEX=3)
+    expect(execGcode).toMatch(/SM_PRINT_START_LINE\s+INDEX=2/);
+    expect(execGcode).toMatch(/SM_PRINT_START_LINE\s+INDEX=3/);
+
+    // Must NOT prime E1 or E2
+    expect(execGcode).not.toMatch(/SM_PRINT_START_LINE\s+INDEX=0/);
+    expect(execGcode).not.toMatch(/SM_PRINT_START_LINE\s+INDEX=1/);
+
+    // Auto-feed must also target E3 and E4 only
+    expect(execGcode).toMatch(/SM_PRINT_AUTO_FEED\s+EXTRUDER=2/);
+    expect(execGcode).toMatch(/SM_PRINT_AUTO_FEED\s+EXTRUDER=3/);
+    expect(execGcode).not.toMatch(/SM_PRINT_AUTO_FEED\s+EXTRUDER=0/);
+    expect(execGcode).not.toMatch(/SM_PRINT_AUTO_FEED\s+EXTRUDER=1/);
+  });
 });


### PR DESCRIPTION
## Summary
- **Fix extruder assignment remapping**: When mapping dual-colour models to non-default extruders (e.g. E3+E4), OrcaSlicer now gets correct positions pre-slice instead of generating T0/T1 and relying on fragile post-processing
- **Zero unused nozzle temps**: Inactive extruder positions get 0°C instead of cloning the last filament's temp, preventing unnecessary heating
- **Improved extruder dropdown UI**: Replaced native `<select>` with custom dropdown showing color swatch + extruder label

## Release Notes
### Fixed
- Multicolour prints mapped to E3+E4 now correctly prime and use those extruders (previously primed E1+E2)
- Unused extruder nozzles no longer heat up during multicolour prints

### Improved
- Extruder assignment dropdown shows color swatches for easier identification

## Test plan
- [x] Full regression suite: 181/181 passed (28.6 min)
- [x] New regression test: `extruder_assignments [2,3]` produces G-code with T2/T3 tools, not T0/T1
- [x] New regression test: `extruder_assignments [2,3]` primes E3+E4, not E1+E2
- [x] Both new tests added to `test:fast` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)